### PR TITLE
Have `get_param` (optionally) return samples grouped by MCMC chain.

### DIFF
--- a/brmp/backend.py
+++ b/brmp/backend.py
@@ -127,11 +127,3 @@ def flatten(arr):
 # (num_chains * num_samples, ...) -> (num_chains, num_samples, ...)
 def unflatten(arr, num_chains, num_samples):
     return arr.reshape((num_chains, num_samples) + arr.shape[1:])
-
-def main():
-    import torch
-    t = torch.rand(2, 10, 3)
-    assert torch.equal(unflatten(flatten(t), 2, 10), t)
-
-if __name__ == '__main__':
-    main()

--- a/brmp/fit.py
+++ b/brmp/fit.py
@@ -121,7 +121,7 @@ def fitted(fit, what='expectation', data=None):
                   else data_from_numpy(fit.backend, predictors(fit.formula, data, fit.metadata, fit.contrasts)))
 
     if what == 'sample' or what == 'expectation':
-        args = [mu if name == 'mu' else get_param(name)
+        args = [mu if name == 'mu' else get_param(name, False)
                 for name in free_param_names(fit.model_desc.response.family)]
         response_fn = sample_response if what == 'sample' else expected_response
         return to_numpy(response_fn(*args))
@@ -167,9 +167,9 @@ def print_model(fit):
 
 # A back end agnostic wrapper around back end specific implementations
 # of `fit.samples.get_param`.
-def get_param(fit, name):
+def get_param(fit, name, preserve_chains=False):
     assert type(fit) == Fit
-    return fit.backend.to_numpy(fit.samples.get_param(name))
+    return fit.backend.to_numpy(fit.samples.get_param(name, preserve_chains))
 
 # TODO: If parameter and scalar parameter names never clash, perhaps
 # having a single lookup method would be convenient. Perhaps this


### PR DESCRIPTION
This extends the `get_param` function to include a `preserve_chains` argument. This makes it possible to extract samples grouped by MCMC chain from a `fit` object.

The motivation for this is to make it possible to compute MCMC diagnostics. After this change is merged, we'll be able to do things like:

```python
import pandas as pd
import numpy as np
from brmp import defm
from brmp.fit import get_param
from numpyro.diagnostics import effective_sample_size, gelman_rubin

df = pd.DataFrame(dict(
    y=np.random.randn(100),
))

fit = defm('y ~ 1', df).fit(iter=100, num_chains=2)

print(effective_sample_size(get_param(fit, 'b', True)))
print(gelman_rubin(get_param(fit, 'b', True)))
```