### PR TITLE
Move shared default inference arguments to public inference methods.

### DIFF
--- a/brmp/__init__.py
+++ b/brmp/__init__.py
@@ -103,14 +103,15 @@ class GenerateResult():
         samples = getattr(self.backend, algo)(self.data, self.model, *args, **kwargs)
         return Fit(self.defm_result.formula, self.defm_result.metadata, self.defm_result.contrasts, self.data, self.defm_result.desc, self.model, samples, self.backend)
 
-    def prior(self, *args, **kwargs):
-        return self._run_algo('prior', *args, **kwargs)
+    def prior(self, num_samples=10, *args, **kwargs):
+        return self._run_algo('prior', num_samples, *args, **kwargs)
 
-    def nuts(self, *args, **kwargs):
-        return self._run_algo('nuts', *args, **kwargs)
+    def nuts(self, iter=10, warmup=None, num_chains=1, *args, **kwargs):
+        warmup = iter // 2 if warmup is None else warmup
+        return self._run_algo('nuts', iter, warmup, num_chains, *args, **kwargs)
 
-    def svi(self, *args, **kwargs):
-        return self._run_algo('svi', *args, **kwargs)
+    def svi(self, iter=10, num_samples=10, *args, **kwargs):
+        return self._run_algo('svi', iter, num_samples, *args, **kwargs)
 
 
 def brm(formula_str, df, family=None, priors=None, **kwargs):

--- a/brmp/backend.py
+++ b/brmp/backend.py
@@ -110,9 +110,3 @@ Model = namedtuple('Model', [
     'expected_response_fn', 'expected_response_code',
     'sample_response_fn', 'sample_response_code',
 ])
-
-def apply_default_hmc_args(iter, warmup, num_chains):
-    iter = 10 if iter is None else iter
-    warmup = iter // 2 if warmup is None else warmup
-    num_chains = 1 if num_chains is None else num_chains
-    return iter, warmup, num_chains

--- a/brmp/numpyro_backend.py
+++ b/brmp/numpyro_backend.py
@@ -8,7 +8,7 @@ from jax.config import config; config.update("jax_platform_name", "cpu")
 import numpyro.handlers as handler
 from numpyro.mcmc import MCMC, NUTS
 
-from brmp.backend import Backend, Model, apply_default_hmc_args
+from brmp.backend import Backend, Model
 from brmp.fit import Samples
 from brmp.numpyro_codegen import gen
 from brmp.utils import flatten, unflatten
@@ -58,12 +58,13 @@ def location(original_data, samples, transformed_samples, model_fn, new_data):
     else:
         return flatten(run_model_on_samples_and_data(model_fn, samples, new_data)['mu'])
 
-def nuts(data, model, seed=None, iter=None, warmup=None, num_chains=None):
+def nuts(data, model, iter, warmup, num_chains, seed=None):
     assert type(data) == dict
     assert type(model) == Model
+    assert type(iter) == int
+    assert type(warmup) == int
+    assert type(num_chains) == int
     assert seed is None or type(seed) == int
-
-    iter, warmup, num_chains = apply_default_hmc_args(iter, warmup, num_chains)
 
     if seed is None:
         seed = np.random.randint(0, 2**32, dtype=np.uint32).astype(np.int32)


### PR DESCRIPTION
This change moves the default inference arguments that are shared across back ends to the methods of the `GenerateResult` class. The idea is that by doing so we make them easier to document, as these methods are part of the public interface.

Tests pass locally.