### PR TITLE
Fixes to comply with flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ dist: xenial
 
 install:
     - pip install -U pip
-    - pip install -e .
+    - pip install -e .[test]
     - pip freeze
 
 branches:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ all: test
 clean: FORCE
 	git clean -dfx -e brmp.egg-info
 
+docs: FORCE
+	$(MAKE) -C docs html
+
 install: FORCE
 	pip install -e .
 
@@ -12,10 +15,10 @@ format: FORCE
 lint: FORCE
 	flake8
 
-test: FORCE
+test: lint FORCE
 	pytest -vs tests --tb=short
 
-test-all: FORCE
+test-all: lint FORCE
 	RUN_SLOW=1 pytest -vs tests --tb=short
 
 FORCE:

--- a/brmp/__init__.py
+++ b/brmp/__init__.py
@@ -1,18 +1,18 @@
 import numpy as np
 import pandas as pd
 
-from brmp.formula import parse, Formula
-from brmp.design import makedata, Metadata, metadata_from_df, code_lengths
-from brmp.fit import Fit
-from brmp.backend import Backend
+from brmp.backend import Backend, data_from_numpy
+from brmp.design import Metadata, code_lengths, makedata, metadata_from_df
 from brmp.family import Family, Normal
-from brmp.priors import build_prior_tree
-from brmp.model_pre import build_model_pre
+from brmp.fit import Fit
+from brmp.formula import Formula, parse
 from brmp.model import build_model, model_repr
+from brmp.model_pre import build_model_pre
+from brmp.priors import build_prior_tree
 from brmp.pyro_backend import backend as pyro_backend
-from brmp.backend import data_from_numpy
 
 _default_backend = pyro_backend
+
 
 def makedesc(formula, metadata, family, priors, code_lengths):
     assert type(formula) == Formula
@@ -22,6 +22,7 @@ def makedesc(formula, metadata, family, priors, code_lengths):
     model_desc_pre = build_model_pre(formula, metadata, family, code_lengths)
     prior_tree = build_prior_tree(model_desc_pre, priors)
     return build_model(model_desc_pre, prior_tree)
+
 
 def defm(formula_str, df, family=None, priors=None, contrasts=None):
     """
@@ -77,6 +78,7 @@ def defm(formula_str, df, family=None, priors=None, contrasts=None):
     desc = makedesc(formula, metadata, family, priors, code_lengths(contrasts))
     data = makedata(formula, df, metadata, contrasts)
     return DefmResult(formula, metadata, contrasts, desc, data)
+
 
 # A wrapper around a pair of model and data. Has a friendly `repr` and
 # makes it easy to fit the model.
@@ -143,6 +145,7 @@ class DefmResult:
     def __repr__(self):
         return model_repr(self.desc)
 
+
 # A wrapper around the result of calling DefmResult#generate. Exists
 # to support the following interface:
 #
@@ -163,7 +166,8 @@ class GenerateResult():
 
     def _run_algo(self, algo, *args, **kwargs):
         samples = getattr(self.backend, algo)(self.data, self.model, *args, **kwargs)
-        return Fit(self.defm_result.formula, self.defm_result.metadata, self.defm_result.contrasts, self.data, self.defm_result.desc, self.model, samples, self.backend)
+        return Fit(self.defm_result.formula, self.defm_result.metadata, self.defm_result.contrasts, self.data,
+                   self.defm_result.desc, self.model, samples, self.backend)
 
     def prior(self, num_samples=10, *args, **kwargs):
         """

--- a/brmp/backend.py
+++ b/brmp/backend.py
@@ -94,12 +94,14 @@ from collections import namedtuple
 
 Backend = namedtuple('Backend', 'name gen prior nuts svi from_numpy to_numpy')
 
+
 # Map `from_numpy` over a dict of numpy arrays, (As produced by e.g.
 # `makedata`.)
 def data_from_numpy(backend, data):
     assert type(backend) == Backend
     assert type(data) == dict
     return {k: backend.from_numpy(arr) for k, arr in data.items()}
+
 
 # We could have a class that wraps a (function, code) pair, making the
 # code available via a code property and the function available via

--- a/brmp/design.py
+++ b/brmp/design.py
@@ -1,17 +1,17 @@
-from collections import namedtuple, OrderedDict
 import itertools
-from functools import reduce
 import operator as op
 import random
+from collections import OrderedDict, namedtuple
+from functools import reduce
 
 import numpy as np
 import pandas as pd
 # http://pandas.pydata.org/pandas-docs/stable/reference/general_utility_functions.html#dtype-introspection
-from pandas.api.types import is_categorical_dtype, is_integer_dtype, is_float_dtype
+from pandas.api.types import (is_categorical_dtype, is_float_dtype,
+                              is_integer_dtype)
 
-from brmp.utils import join
 from brmp.formula import Formula, OrderedSet, Term, allfactors
-
+from brmp.utils import join
 
 # TODO: Levels of pandas categorical columns can be any hashable type
 # I think. Is our implementation flexible enough to handle the same?
@@ -24,13 +24,14 @@ from brmp.formula import Formula, OrderedSet, Term, allfactors
 # converted to strings in a sensible way.)
 
 Categorical = namedtuple('Categorical',
-                         ['name',    # column name
-                          'levels']) # list of level names
+                         ['name',     # column name
+                          'levels'])  # list of level names
 
 Integral = namedtuple('Integral',
                       ['name',
                        'min',
                        'max'])
+
 
 class RealValued(namedtuple('RealValued', ['name', 'min', 'max'])):
     def __new__(cls, name, min=-np.inf, max=np.inf):
@@ -39,9 +40,11 @@ class RealValued(namedtuple('RealValued', ['name', 'min', 'max'])):
         assert max >= min
         return super(RealValued, cls).__new__(cls, name, min, max)
 
+
 def is_numeric_col(col):
     assert type(col) in [Categorical, Integral, RealValued]
     return not type(col) == Categorical
+
 
 # TODO: This is rather a long way from idiomatic Python code.
 # Re-implement Metadata as a class, perhaps with subclasses for
@@ -64,22 +67,25 @@ def is_numeric_col(col):
 #
 Metadata = namedtuple('Metadata', 'columns column levels')
 
+
 def make_column_lookup(columns):
     assert type(columns) == list
     assert all(type(col) in [Categorical, Integral, RealValued] for col in columns)
     # Turn a list of columns into a dictionary keyed by column name.
     return dict((col.name, col) for col in columns)
 
+
 def df_levels(columns, df):
     assert type(columns) == list
     assert all(type(col) == str for col in columns)
     assert type(df) == pd.DataFrame
     assert all(col in df and is_categorical_dtype(df[col]) for col in columns)
-    vals = [tuple(row) for _,row in df[columns].iterrows()]
+    vals = [tuple(row) for _, row in df[columns].iterrows()]
     present = set(vals)
     all_possible_vals = list(itertools.product(*[df[col].cat.categories for col in columns]))
     table = [val for val in all_possible_vals if val in present]
     return table
+
 
 # Extract column information from a pandas dataframe.
 def dfcols(df):
@@ -94,11 +100,13 @@ def dfcols(df):
             raise Exception('unhandled column type encountered for column "{}"'.format(dfcol.name))
     return [dispatch(df[c]) for c in df]
 
+
 def metadata_from_df(df):
     assert type(df) == pd.DataFrame
     cols = dfcols(df)
     lu = make_column_lookup(cols)
     return Metadata(cols, lambda name: lu[name], lambda names: df_levels(names, df))
+
 
 def all_levels(names, metadata_lookup):
     assert type(names) == list
@@ -107,6 +115,7 @@ def all_levels(names, metadata_lookup):
     assert all(name in metadata_lookup and type(metadata_lookup[name]) == Categorical for name in names)
     all_possible_vals = list(itertools.product(*[metadata_lookup[name].levels for name in names]))
     return all_possible_vals
+
 
 # Makes the assumption that all possible levels are present. The idea
 # is that this is sufficient to allow us to generate model code from
@@ -124,6 +133,7 @@ def metadata_from_cols(cols):
 def dummy_df(cols, N):
     assert type(cols) == list
     assert all(type(col) in [RealValued, Categorical, Integral] for col in cols)
+
     def gen_numeric_col(factor):
         if np.isfinite(factor.min) and np.isfinite(factor.max):
             return np.random.uniform(factor.min, factor.max, N)
@@ -133,10 +143,13 @@ def dummy_df(cols, N):
             return factor.max - np.abs(np.random.randn(N))
         else:
             return np.random.randn(N)
+
     def gen_categorical_col(levels):
         return pd.Categorical(random.choices(levels, k=N))
+
     def gen_integral_col(factor):
         return np.random.randint(factor.min, factor.max + 1, N)
+
     def dispatch(col):
         if type(col) == RealValued:
             return gen_numeric_col(col)
@@ -146,7 +159,9 @@ def dummy_df(cols, N):
             return gen_integral_col(col)
         else:
             raise Exception('unknown factor type')
+
     return pd.DataFrame({col.name: dispatch(col) for col in cols})
+
 
 def dummy_design(formula, metadata, N):
     assert type(formula) == Formula
@@ -158,16 +173,19 @@ def dummy_design(formula, metadata, N):
 # Design matrix coding
 # --------------------
 
+
 # A version of product in which earlier elements of the returned
 # tuples vary more rapidly than later ones. This matches the way
 # interactions are coded in R.
 def product(iterables):
     return [tuple(reversed(t)) for t in itertools.product(*reversed(iterables))]
 
+
 # Taken from the itertools documentation.
 def powerset(iterable):
     s = list(iterable)
     return itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(len(s)+1))
+
 
 # A Term represents the interaction between zero or more factors. This
 # function describes how the coding for such a term can be performed
@@ -176,7 +194,6 @@ def powerset(iterable):
 #
 # Term(<'a'>) can be coded as [Intercept, a (reduced)].
 # Term(<'a','b'>) can be coded as [Intercept, a (reduced), b (reduced), a:b (reduced)].
-
 def decompose(term):
     assert type(term) == Term
     return [tuple(CategoricalCoding(factor, True) for factor in subset) for subset in powerset(term.factors)]
@@ -235,6 +252,7 @@ def absorb(t1, t2):
             factor = CategoricalCoding(extra_factor.factor, False)
             return tuple((factor if f == extra_factor else f) for f in t1)
 
+
 def simplify_one(termcoding):
     assert type(termcoding) == list
     assert all(type(t) == tuple and all(type(p) == CategoricalCoding for p in t) for t in termcoding)
@@ -242,9 +260,10 @@ def simplify_one(termcoding):
         newterm = absorb(termcoding[i], termcoding[j])
         if newterm:
             out = termcoding[:]
-            out[i] = newterm # Replace with absorbing interaction.
-            del out[j]       # Remove absorbed interaction.
+            out[i] = newterm  # Replace with absorbing interaction.
+            del out[j]        # Remove absorbed interaction.
             return out
+
 
 def simplify(termcoding):
     assert type(termcoding) == list
@@ -252,8 +271,9 @@ def simplify(termcoding):
     while True:
         maybe_termcoding = simplify_one(termcoding)
         if maybe_termcoding is None:
-            return termcoding # We're done.
+            return termcoding  # We're done.
         termcoding = maybe_termcoding
+
 
 # all_previous([['a'], ['b','c'], ['d']])
 # ==           [{},    {'a'},     {'a','b','c'}]
@@ -271,7 +291,7 @@ def code_categorical_terms(terms):
     # It is assumed that each element of `terms` describes an
     # interaction between zero or more categorical factors.
     decomposed = [decompose(t) for t in terms]
-    non_redundant = [[t for t in term if not t in previous]
+    non_redundant = [[t for t in term if t not in previous]
                      for term, previous in zip(decomposed, all_previous(decomposed))]
     return [simplify(t) for t in non_redundant]
 
@@ -280,14 +300,15 @@ def partition(pred, iterable):
     t1, t2 = itertools.tee(iterable)
     return list(itertools.filterfalse(pred, t1)), list(filter(pred, t2))
 
+
 CategoricalCoding = namedtuple('CategoricalCoding', 'factor reduced')
 CategoricalCoding.__repr__ = lambda self: '{}{}'.format(self.factor, '-' if self.reduced else '+')
 
 NumericCoding = namedtuple('NumericCoding', ['factor'])
 NumericCoding.__repr__ = lambda self: self.factor
 
-# Codes a group of terms that all share a common set of numeric factors.
 
+# Codes a group of terms that all share a common set of numeric factors.
 # Returns a list of coded interactions.
 
 def code_group_of_terms(terms, shared_numeric_factors):
@@ -301,7 +322,7 @@ def code_group_of_terms(terms, shared_numeric_factors):
     assert all(all((factor in term.factors) for factor in shared_numeric_factors) for term in terms)
 
     def drop_numeric_factors(term):
-        factors = [f for f in term.factors if not f in shared_numeric_factors]
+        factors = [f for f in term.factors if f not in shared_numeric_factors]
         return Term(OrderedSet(*factors))
 
     categorical_terms = [drop_numeric_factors(term) for term in terms]
@@ -332,7 +353,7 @@ def code_group_of_terms(terms, shared_numeric_factors):
         assert len(out) == len(codings_dict)
         return out
 
-    assert len(terms) == len(codings_for_terms) # complain if zip will drop things
+    assert len(terms) == len(codings_for_terms)  # complain if zip will drop things
     return join([[extend_with_numeric_factors(term, coding) for coding in codings]
                  for (term, codings) in zip(terms, codings_for_terms)])
 
@@ -347,7 +368,7 @@ def group(pairs):
     # input list.
     out = OrderedDict()
     for (k, v) in pairs:
-        if not k in out:
+        if k not in out:
             out[k] = []
         out[k].append(v)
     return out
@@ -378,10 +399,10 @@ def partition_terms(terms, metadata):
     return first + rest
 
 
-
 def code_lengths(contrasts):
     assert type(contrasts) == dict
-    return {k:mat.shape[1] for k,mat in contrasts.items()}
+    return {k: mat.shape[1] for k, mat in contrasts.items()}
+
 
 # Build a simple design matrix (as a torch tensor) from columns of a
 # pandas data frame.
@@ -415,6 +436,7 @@ def designmatrix(terms, df, metadata, contrasts):
 def sort_by_order(terms):
     return sorted(terms, key=lambda term: len(term.factors))
 
+
 def code_terms(terms, metadata):
     assert type(metadata) == Metadata
     groups = partition_terms(terms, metadata)
@@ -434,7 +456,7 @@ NumericCol = namedtuple('NumericCol', ['factor'])
 NumericCol.__repr__ = lambda self: 'Num({})'.format(self.factor)
 
 # Represents the product of zero of more columns.
-ProductCol = namedtuple('ProductCol', ['cols']) # `cols` is expected to be a list
+ProductCol = namedtuple('ProductCol', ['cols'])  # `cols` is expected to be a list
 
 
 def coded_interaction_to_product_cols(coded_interaction, metadata, code_lengths):
@@ -463,6 +485,7 @@ def coded_interaction_to_product_cols(coded_interaction, metadata, code_lengths)
     interactions = product([go(c) for c in cs])
 
     ncols_dict = {n.factor: NumericCol(n.factor) for n in ns}
+
     def extend_with_numeric_cols(ccols):
         ccols_dict = {ccol.factor: ccol for ccol in ccols}
         cols_dict = dict(ccols_dict, **ncols_dict)
@@ -543,6 +566,7 @@ def execute_product_col(product_col, df, metadata, contrasts):
     assert arr.shape[0] == N
     return arr
 
+
 def coef_names(terms, metadata, code_lengths):
     assert type(terms) == OrderedSet
     assert type(metadata) == Metadata
@@ -550,6 +574,7 @@ def coef_names(terms, metadata, code_lengths):
     product_cols = join(coded_interaction_to_product_cols(code, metadata, code_lengths)
                         for code in coded_interactions)
     return [product_col_to_coef_name(pcol) for pcol in product_cols]
+
 
 # --------------------------------------------------
 
@@ -563,8 +588,9 @@ def lookupvector(columns, df, metadata):
     # For each row in the data, look up its combination of grouping
     # columns values in the table, using the position of the matching
     # row as the index.
-    indices = [table.index(tuple(row)) for _,row in df[columns].iterrows()]
+    indices = [table.index(tuple(row)) for _, row in df[columns].iterrows()]
     return np.array(indices, dtype=np.int64)
+
 
 def responsevector(column, df, metadata):
     assert type(column) == str
@@ -584,6 +610,7 @@ def responsevector(column, df, metadata):
     assert len(pcols) == 1
     return execute_product_col(pcols[0], df, metadata, {})
 
+
 def predictors(formula, df, metadata, contrasts):
     assert type(formula) == Formula
     assert type(df) == pd.DataFrame
@@ -593,6 +620,7 @@ def predictors(formula, df, metadata, contrasts):
         data['Z_{}'.format(i)] = designmatrix(group.terms, df, metadata, contrasts)
         data['J_{}'.format(i)] = lookupvector(group.columns, df, metadata)
     return data
+
 
 def makedata(formula, df, metadata, contrasts):
     return dict(predictors(formula, df, metadata, contrasts),

--- a/brmp/family.py
+++ b/brmp/family.py
@@ -1,6 +1,6 @@
+import inspect
 from collections import namedtuple
 from enum import Enum
-import inspect
 from functools import partial
 
 # This is intended to be independent of Pyro, with a view to
@@ -13,25 +13,32 @@ Family.__repr__ = lambda self: family_repr(self)
 
 # TODO: Check that `value` is in `type` (or None).
 Param = namedtuple('Param', 'name type value')
+
+
 def param(name, typ):
     return Param(name, typ, None)
 
+
 def mktype(*args):
     out = namedtuple(*args)
+
     def eq(a, b):
         return type(a) == type(b) and tuple(a) == tuple(b)
+
     out.__eq__ = eq
     out.__ne__ = lambda a, b: not eq(a, b)
     return out
 
+
 Type = dict(
-    Real         = mktype('Real', ''),
-    PosReal      = mktype('PosReal', ''),
-    Boolean      = mktype('Boolean', ''),
-    UnitInterval = mktype('UnitInterval', ''),
-    CorrCholesky = mktype('CorrCholesky', ''),
-    IntegerRange = mktype('IntegerRange', 'lb ub'),
+    Real=mktype('Real', ''),
+    PosReal=mktype('PosReal', ''),
+    Boolean=mktype('Boolean', ''),
+    UnitInterval=mktype('UnitInterval', ''),
+    CorrCholesky=mktype('CorrCholesky', ''),
+    IntegerRange=mktype('IntegerRange', 'lb ub'),
 )
+
 
 def istype(ty):
     return type(ty) in Type.values()
@@ -41,6 +48,7 @@ def istype(ty):
 LinkFn = Enum('LinkFn', 'identity logit inverse')
 
 Link = namedtuple('Link', 'param fn')
+
 
 # TODO: Code generation currently assumes that the parameters appear
 # here in the order expected by Pyro + NumPyro distribution
@@ -55,26 +63,28 @@ Link = namedtuple('Link', 'param fn')
 def const(x):
     def f(*args):
         return x
+
     return f
 
-Normal     = Family('Normal',
-                    [param('mu', Type['Real']()), param('sigma', Type['PosReal']())],
-                    const(Type['Real']()),
-                    Link('mu', LinkFn.identity))
+
+Normal = Family('Normal',
+                [param('mu', Type['Real']()), param('sigma', Type['PosReal']())],
+                const(Type['Real']()),
+                Link('mu', LinkFn.identity))
 """
 :param mu: mean
 :param sigma: standard deviation
 """
-Bernoulli  = Family('Bernoulli',
-                    [param('probs', Type['UnitInterval']())],
-                    const(Type['Boolean']()),
-                    Link('probs', LinkFn.logit))
+Bernoulli = Family('Bernoulli',
+                   [param('probs', Type['UnitInterval']())],
+                   const(Type['Boolean']()),
+                   Link('probs', LinkFn.logit))
 """
 :param probs: success probability
 """
-Cauchy     = Family('Cauchy',
-                    [param('loc', Type['Real']()), param('scale', Type['PosReal']())],
-                    const(Type['Real']()), None)
+Cauchy = Family('Cauchy',
+                [param('loc', Type['Real']()), param('scale', Type['PosReal']())],
+                const(Type['Real']()), None)
 """
 :param loc: location
 :param scale: scale
@@ -85,17 +95,17 @@ HalfCauchy = Family('HalfCauchy',
 """
 :param scale: scale
 """
-LKJ        = Family('LKJ',
-                    [param('eta', Type['PosReal']())],
-                    const(Type['CorrCholesky']()), None)
+LKJ = Family('LKJ',
+             [param('eta', Type['PosReal']())],
+             const(Type['CorrCholesky']()), None)
 """
 :param eta: shape
 """
-Binomial   = Family('Binomial',
-                    [param('num_trials', Type['IntegerRange'](0, None)),
-                     param('probs', Type['UnitInterval']())],
-                    lambda num_trials: Type['IntegerRange'](0, num_trials),
-                    Link('probs', LinkFn.logit))
+Binomial = Family('Binomial',
+                  [param('num_trials', Type['IntegerRange'](0, None)),
+                   param('probs', Type['UnitInterval']())],
+                  lambda num_trials: Type['IntegerRange'](0, num_trials),
+                  Link('probs', LinkFn.logit))
 """
 :param num_trials: number of trials
 :param probs: success probability
@@ -108,11 +118,14 @@ HalfNormal = Family('HalfNormal',
 :param sigma: scale
 """
 
+
 def apply1(family, name, value):
     if name not in [p.name for p in family.params]:
         raise Exception('Unknown parameter "{}"'.format(name))
+
     def setval(param, value):
         return Param(param.name, param.type, value)
+
     params = [setval(param, value) if param.name == name else param
               for param in family.params]
     if name in inspect.getfullargspec(family.support).args:
@@ -120,6 +133,7 @@ def apply1(family, name, value):
     else:
         support = family.support
     return Family(family.name, params, support, family.link)
+
 
 # This could be __call__ on a Family class.
 def apply(family, *args, **kwargs):
@@ -132,26 +146,32 @@ def apply(family, *args, **kwargs):
         family = apply1(family, name, value)
     return family
 
+
 def support_depends_on_args(family):
     return len(inspect.getfullargspec(family.support).args) > 0
+
 
 def fully_applied(family):
     return all(param.value is not None for param in family.params)
 
+
 def args(family):
     return [param.value for param in family.params]
+
 
 def family_repr(family):
     params = ', '.join('{}={}'.format(param.name, param.value)
                        for param in family.params
-                       if not param.value is None)
+                       if param.value is not None)
     return '{}({})'.format(family.name, params)
+
 
 def nonlocparams(family):
     assert type(family) == Family
     assert family.link is not None
     return [param for param in family.params
             if not (param.name == family.link.param or param.value is not None)]
+
 
 # Note that the location parameter is always called "mu" in the list
 # returned by this function.
@@ -160,9 +180,3 @@ def free_param_names(family):
     assert family.link is not None
     return ['mu' if param.name == family.link.param else param.name
             for param in family.params if param.value is None]
-
-def main():
-    pass
-
-if __name__ == '__main__':
-    main()

--- a/brmp/fit.py
+++ b/brmp/fit.py
@@ -7,10 +7,8 @@ import pandas as pd
 from brmp.backend import data_from_numpy
 from brmp.design import predictors
 from brmp.family import free_param_names
-from brmp.model import (model_repr, scalar_parameter_map,
-                        scalar_parameter_names)
+from brmp.model import model_repr, scalar_parameter_map, scalar_parameter_names
 from brmp.utils import flatten
-
 
 # `Fit` carries around `formula`, `metadata` and `contrasts` for the
 # sole purpose of being able to encode any new data passed to

--- a/brmp/fit.py
+++ b/brmp/fit.py
@@ -1,14 +1,16 @@
 from collections import namedtuple
 
 import numpy as np
-import pandas as pd
 import numpyro.diagnostics as diags
+import pandas as pd
 
-from brmp.model import model_repr, parameter_names, scalar_parameter_map, scalar_parameter_names
-from brmp.family import free_param_names
-from brmp.design import predictors, metadata_from_df
 from brmp.backend import data_from_numpy
+from brmp.design import predictors
+from brmp.family import free_param_names
+from brmp.model import (model_repr, scalar_parameter_map,
+                        scalar_parameter_names)
 from brmp.utils import flatten
+
 
 # `Fit` carries around `formula`, `metadata` and `contrasts` for the
 # sole purpose of being able to encode any new data passed to
@@ -24,6 +26,7 @@ from brmp.utils import flatten
 # make up data to tinker with a model), it's not clear that deferring
 # having to give contrasts has a similar benefit.
 
+
 class Fit(namedtuple('Fit', 'formula metadata contrasts data model_desc model samples backend')):
     def __repr__(self):
         # The repr of namedtuple ends up long and not very useful for
@@ -31,12 +34,15 @@ class Fit(namedtuple('Fit', 'formula metadata contrasts data model_desc model sa
         # used for classes.
         return '<brmp.fit.Fit at {}>'.format(hex(id(self)))
 
+
 Samples = namedtuple('Samples', ['raw_samples', 'get_param', 'location'])
 
 default_quantiles = [0.025, 0.25, 0.5, 0.75, 0.975]
 
+
 def format_quantiles(qs):
     return ['{:g}%'.format(q * 100) for q in qs]
+
 
 # Computes statistics for an array produced by `marginal`.
 def marginal_stats(arr, qs):
@@ -48,6 +54,7 @@ def marginal_stats(arr, qs):
     quantiles = np.quantile(arr, qs, 0)
     stacked = np.hstack((mean.reshape((-1, 1)), sd.reshape((-1, 1)), quantiles.T))
     return stacked
+
 
 # TODO: Would it be better to replace these tables with pandas data
 # frames? They also let you get at the underlying data as a numpy
@@ -65,8 +72,10 @@ class ArrReprWrapper:
         # Format a float. 2 decimal places, space for sign.
         def ff(x):
             return '{: .2f}'.format(x)
+
         table = [[ff(c) for c in r] for r in self.array.tolist()]
         return layout_table(add_labels(table, self.col_labels, self.row_labels))
+
 
 def add_labels(table, col_labels, row_labels):
     assert type(table) == list
@@ -79,8 +88,8 @@ def add_labels(table, col_labels, row_labels):
         out = [[name] + r for r, name in zip(out, rlabels)]
     return out
 
+
 def layout_table(rows):
-    out = []
     num_rows = len(rows)
     assert num_rows > 0
     num_cols = len(rows[0])
@@ -91,6 +100,7 @@ def layout_table(rows):
             max_widths[i] = max(max_widths[i], len(cell))
     fmt = ' '.join('{{:>{}}}'.format(mw) for mw in max_widths)
     return '\n'.join(fmt.format(*row) for row in rows)
+
 
 # TODO: This doesn't match the brms interface, but the deviation
 # aren't improvements either. Figure out what to do about that.
@@ -148,12 +158,12 @@ def fitted(fit, what='expectation', data=None):
     assert what in ['sample', 'expectation', 'linear', 'response']
     assert data is None or type(data) is pd.DataFrame
 
-    get_param         = fit.samples.get_param
-    location          = fit.samples.location
-    to_numpy          = fit.backend.to_numpy
+    get_param = fit.samples.get_param
+    location = fit.samples.location
+    to_numpy = fit.backend.to_numpy
     expected_response = fit.model.expected_response_fn
-    sample_response   = fit.model.sample_response_fn
-    inv_link          = fit.model.inv_link_fn
+    sample_response = fit.model.sample_response_fn
+    inv_link = fit.model.inv_link_fn
 
     mu = location(fit.data if data is None
                   else data_from_numpy(fit.backend, predictors(fit.formula, data, fit.metadata, fit.contrasts)))
@@ -168,7 +178,7 @@ def fitted(fit, what='expectation', data=None):
     elif what == 'response':
         return to_numpy(inv_link(mu))
     else:
-        raise 'Unhandled value of the `what` parameter encountered.'
+        raise ValueError('Unhandled value of the `what` parameter encountered.')
 
 
 # TODO: We could follow brms and make this available via a `summary`
@@ -177,20 +187,23 @@ def summary(arr, qs=default_quantiles, row_labels=None):
     col_labels = ['mean', 'sd'] + format_quantiles(qs)
     return ArrReprWrapper(marginal_stats(arr, qs), row_labels, col_labels)
 
+
 def gelman_rubin(samples):
     if ((samples.shape[0] < 2 and samples.shape[1] < 4) or
-        (samples.shape[0] >= 2 and samples.shape[1] < 2)):
-        return None # Too few chains or samples.
+            (samples.shape[0] >= 2 and samples.shape[1] < 2)):
+        return None  # Too few chains or samples.
     elif samples.shape[0] >= 2:
         return diags.gelman_rubin(samples)
     else:
         return diags.split_gelman_rubin(samples)
 
+
 def effective_sample_size(samples):
     if samples.shape[1] < 2:
-        return None # Too few samples.
+        return None  # Too few samples.
     else:
         return diags.effective_sample_size(samples)
+
 
 def compute_diag_or_default(diag, samples):
     val = diag(samples)
@@ -198,6 +211,7 @@ def compute_diag_or_default(diag, samples):
         return val
     else:
         return np.full((samples.shape[2],), np.nan)
+
 
 # Similar to the following:
 # https://rdrr.io/cran/rstan/man/stanfit-method-summary.html
@@ -243,17 +257,20 @@ def marginals(fit, qs=default_quantiles):
     stats_arr = marginal_stats(flatten(samples), qs)
     n_eff = compute_diag_or_default(effective_sample_size, samples)
     r_hat = compute_diag_or_default(gelman_rubin, samples)
-    arr = np.hstack([stats_arr, n_eff[...,np.newaxis], r_hat[...,np.newaxis]])
+    arr = np.hstack([stats_arr, n_eff[..., np.newaxis], r_hat[..., np.newaxis]])
     return ArrReprWrapper(arr, names, col_labels)
+
 
 def print_model(fit):
     print(model_repr(fit.model_desc))
+
 
 # A back end agnostic wrapper around back end specific implementations
 # of `fit.samples.get_param`.
 def get_param(fit, name, preserve_chains=False):
     assert type(fit) == Fit
     return fit.backend.to_numpy(fit.samples.get_param(name, preserve_chains))
+
 
 # TODO: If parameter and scalar parameter names never clash, perhaps
 # having a single lookup method would be convenient. Perhaps this

--- a/brmp/formula.py
+++ b/brmp/formula.py
@@ -1,9 +1,10 @@
-import re
-from enum import Enum
-from collections import namedtuple
 import itertools
+import re
+from collections import namedtuple
+from enum import Enum
 
 from brmp.utils import join
+
 
 # Maintains order.
 def unique(xs):
@@ -15,6 +16,7 @@ def unique(xs):
             seen.add(x)
     return out
 
+
 class OrderedSet():
     def __init__(self, *items, items_are_unique=False):
         # For most methods on this class `items` could be an arbitrary
@@ -25,23 +27,31 @@ class OrderedSet():
         # list would work too.
         self.items = tuple(items if items_are_unique else unique(items))
         self.fset = frozenset(self.items)
-        assert len(self.fset) == len(self.items) # `unique` ensures nodups
+        assert len(self.fset) == len(self.items)  # `unique` ensures nodups
+
     def __hash__(self):
         return hash((OrderedSet, self.fset))
+
     def __eq__(self, other):
         return self.fset == other.fset
+
     def __iter__(self):
         return self.items.__iter__()
+
     def __next__(self):
         return self.items.__next__()
+
     def __len__(self):
         return len(self.items)
+
     def __getitem__(self, i):
         return self.items[i]
+
     def __repr__(self):
         return '<{}>'.format(','.join(str(item) for item in self.items))
+
     def union(self, other):
-        items = self.items + tuple(x for x in other.items if not x in self.fset)
+        items = self.items + tuple(x for x in other.items if x not in self.fset)
         return OrderedSet(*items, items_are_unique=True)
 
 
@@ -52,11 +62,11 @@ Op = namedtuple('Op', 'name assoc precedence')
 Var = namedtuple('Var', 'name')
 
 OPS = {
-    ':':  Op(':',  Assoc.L, 5),
-    '+':  Op('+',  Assoc.L, 4),
+    ':': Op(':', Assoc.L, 5),
+    '+': Op('+', Assoc.L, 4),
     '||': Op('||', Assoc.L, 3),
-    '|':  Op('|',  Assoc.L, 3),
-    '~':  Op('~',  Assoc.L, 2),
+    '|': Op('|', Assoc.L, 3),
+    '~': Op('~', Assoc.L, 2),
 }
 
 # AST
@@ -77,9 +87,9 @@ Node = namedtuple('Node', 'op l r')
 # TODO: I don't think attaching these docs to the "private" `Formula`
 # class makes much sense. What's a better alternative?
 Formula = namedtuple('Formula',
-                     ['response',   # response column name
-                      'terms',      # an OrderedSet of population level terms
-                      'groups'])    # list of groups
+                     ['response',  # response column name
+                      'terms',  # an OrderedSet of population level terms
+                      'groups'])  # list of groups
 """
 Represents an lme4 formula.
 
@@ -114,30 +124,32 @@ The following examples are all parsed as valid formulae:
 
 """
 
-
-
 Group = namedtuple('Group',
-                   ['terms',        # an OrderedSet of group-level terms
-                    'columns',      # names of grouping columns
-                    'corr'])        # model correlation between coeffs?
-
+                   ['terms',  # an OrderedSet of group-level terms
+                    'columns',  # names of grouping columns
+                    'corr'])  # model correlation between coeffs?
 
 # TODO: Make it possible to union terms directly? (Could use in the
 # `:` case of eval.)
 Term = namedtuple('Term',
-                  ['factors']) # Factors in the Patsy sense. An OrderedSet.
-_1 = Term(OrderedSet()) # Intercept
+                  ['factors'])  # Factors in the Patsy sense. An OrderedSet.
+_1 = Term(OrderedSet())  # Intercept
+
 
 def allfactors(formula):
     assert type(formula) == Formula
+
     def all_from_terms(terms):
         return join(list(term.factors) for term in terms)
+
     return ([formula.response] +
             all_from_terms(formula.terms) +
             join(all_from_terms(group.terms) + group.columns for group in formula.groups))
 
+
 def tokenize(inp):
     return [str2token(s) for s in re.findall(r'\b\w+\b|[()~+:]|\|\|?', inp)]
+
 
 def str2token(s):
     if s in OPS:
@@ -148,6 +160,7 @@ def str2token(s):
         return Paren.R
     else:
         return Var(s)
+
 
 # https://en.wikipedia.org/wiki/Shunting-yard_algorithm
 # TODO: Add better error handling. (Wiki article has some extra checks
@@ -178,6 +191,7 @@ def shunt(tokens):
         output.append(opstack.pop())
     return output
 
+
 # Evaluate rpn (as produced by `shunt`) to an ast.
 def rpn2ast(tokens):
     out = []
@@ -193,6 +207,7 @@ def rpn2ast(tokens):
             raise Exception('unhandled token type')
     assert len(out) == 1
     return out[0]
+
 
 # Returns an ordered set of population-level terms and a list of
 # groups.
@@ -232,6 +247,7 @@ def eval_rhs(ast, allow_groups=True):
         # use. e.g. When nested groups are present.
         raise Exception('unhandled ast')
 
+
 # Evaluate the expression to the right of the `|` or `||` in a group
 # to a list of factor names.
 # e.g. `a:b:c` -> ['a', 'b', 'c']
@@ -247,6 +263,7 @@ def eval_group_rhs(ast):
         # that the whole group can be included in the message?
         raise Exception('unhandled ast')
 
+
 # Evaluate a formula of the form `y ~ <rhs>`, where the rhs is a sum
 # of population terms and groups.
 def evalf(ast):
@@ -256,11 +273,14 @@ def evalf(ast):
     terms, groups = eval_rhs(ast.r)
     return Formula(ast.l.value, terms, groups)
 
+
 def parse(s):
     return evalf(rpn2ast(shunt(tokenize(s))))
 
+
 def main():
     print(parse('y ~ x1 + x2 + (1 + x3 | x4) + x5:x6'))
+
 
 if __name__ == '__main__':
     main()

--- a/brmp/model_pre.py
+++ b/brmp/model_pre.py
@@ -1,8 +1,10 @@
 from collections import namedtuple
 
+from brmp.design import Categorical, Integral, Metadata, RealValued, coef_names
+from brmp.family import (Family, Type, family_repr, nonlocparams,
+                         support_depends_on_args)
 from brmp.formula import Formula, allfactors
-from brmp.design import Metadata, coef_names, RealValued, Categorical, Integral
-from brmp.family import Family, Type, nonlocparams, support_depends_on_args, family_repr
+
 
 def family_matches_response(formula, metadata, family):
     assert type(formula) == Formula
@@ -38,14 +40,17 @@ def family_matches_response(formula, metadata, family):
     else:
         return False
 
+
 def check_family_matches_response(formula, metadata, family):
     assert type(metadata) == Metadata
     if not family_matches_response(formula, metadata, family):
         # TODO: This could be more informative. e.g. If choosing
         # Bernoulli fails, is the problem that the response is
         # numeric, or that it has more than two levels?
-        error = 'The response distribution "{}" is not compatible with the type or contents of the response column "{}".'
+        error = 'The response distribution "{}" is not compatible with the type or contents of the ' \
+                'response column "{}".'
         raise Exception(error.format(family_repr(family), formula.response))
+
 
 # `ModelDescPre` is an intermediate step towards a full `ModelDesc`.
 # At this stage we know how the data will be coded, and therefore know
@@ -61,6 +66,7 @@ PopulationPre = namedtuple('PopulationPre', 'coefs')
 GroupPre = namedtuple('GroupPre', 'columns levels coefs corr')
 ResponsePre = namedtuple('ResponsePre', 'family nonlocparams')
 
+
 def build_model_pre(formula, metadata, family, custom_code_lengths):
     assert type(formula) == Formula
     assert type(metadata) == Metadata
@@ -73,7 +79,9 @@ def build_model_pre(formula, metadata, family, custom_code_lengths):
 
     gs = []
     for group in formula.groups:
-        assert all(type(metadata.column(col)) == Categorical for col in group.columns), 'grouping columns must be a factor'
+        assert all(
+            type(metadata.column(col)) == Categorical for col in group.columns), \
+            'grouping columns must be a factor'
         coefs = coef_names(group.terms, metadata, custom_code_lengths)
         g = GroupPre(group.columns, metadata.levels(group.columns), coefs, group.corr and len(coefs) > 1)
         gs.append(g)

--- a/brmp/numpyro_backend.py
+++ b/brmp/numpyro_backend.py
@@ -3,14 +3,13 @@ from functools import partial
 import numpy as np
 import numpyro.handlers as handler
 from jax import random, vmap
+from jax.config import config
 from numpyro.mcmc import MCMC, NUTS
 
 from brmp.backend import Backend, Model
 from brmp.fit import Samples
 from brmp.numpyro_codegen import gen
 from brmp.utils import flatten, unflatten
-
-from jax.config import config
 
 config.update("jax_platform_name", "cpu")
 

--- a/brmp/priors.py
+++ b/brmp/priors.py
@@ -1,12 +1,8 @@
-from collections import namedtuple, defaultdict
-from pprint import pprint as pp
+from collections import defaultdict, namedtuple
 
-import pandas as pd
-
+from brmp.family import LKJ, Cauchy, Family, HalfCauchy, Type, fully_applied
+from brmp.model_pre import GroupPre, ModelDescPre, PopulationPre
 from brmp.utils import join
-from brmp.formula import Formula
-from brmp.model_pre import ModelDescPre, PopulationPre, GroupPre
-from brmp.family import Cauchy, HalfCauchy, LKJ, Family, Type, fully_applied
 
 # `is_param` indicates whether a node corresponds to a parameter in
 # the model. (Nodes without this flag set exist only to add structure
@@ -14,8 +10,10 @@ from brmp.family import Cauchy, HalfCauchy, LKJ, Family, Type, fully_applied
 # information from the tree.
 Node = namedtuple('Node', 'name prior_edit is_param checks children')
 
+
 def leaf(name, prior_edit=None, checks=[]):
     return Node(name, prior_edit, True, checks, [])
+
 
 RESPONSE_PRIORS = {
     'Normal': {
@@ -23,9 +21,11 @@ RESPONSE_PRIORS = {
     },
 }
 
+
 def get_response_prior(family, parameter):
     if family in RESPONSE_PRIORS:
         return RESPONSE_PRIORS[family][parameter]
+
 
 # This is similar to brms `set_prior`. (e.g. `set_prior('<prior>',
 # coef='x1')` is similar to `Prior(['x1'], '<prior>)`.) By specifying
@@ -82,6 +82,7 @@ Example::
 :type prior: brmp.family.Family
 """
 
+
 def walk(node, path):
     assert type(node) == Node
     assert type(path) == tuple
@@ -94,8 +95,10 @@ def walk(node, path):
             raise ValueError('Invalid path')
         return [node] + walk(selected_node, path[1:])
 
+
 def select(node, path):
     return walk(node, path)[-1]
+
 
 def edit(node, path, f):
     assert type(node) == Node
@@ -114,6 +117,7 @@ def edit(node, path, f):
         children = [edit(n, path[1:], f) if n.name == name else n
                     for n in node.children]
         return Node(node.name, node.prior_edit, node.is_param, node.checks, children)
+
 
 # TODO: Match default priors used by brms. (An improper uniform is
 # used for `b`. A Half Student-t here is used for priors on standard
@@ -136,7 +140,8 @@ def default_prior(model_desc_pre):
     assert all(type(gm) == GroupPre for gm in model_desc_pre.groups)
     b_children = [leaf(name) for name in model_desc_pre.population.coefs]
     cor_children = [leaf(cols2str(group.columns)) for group in model_desc_pre.groups if group.corr]
-    sd_children = [Node(cols2str(gm.columns), None, False, [], [leaf(name) for name in gm.coefs]) for gm in model_desc_pre.groups]
+    sd_children = [Node(cols2str(gm.columns), None, False, [], [leaf(name) for name in gm.coefs]) for gm in
+                   model_desc_pre.groups]
 
     def mk_resp_prior_edit(param_name):
         prior = get_response_prior(family.name, param_name)
@@ -146,10 +151,11 @@ def default_prior(model_desc_pre):
     resp_children = [leaf(p.name, mk_resp_prior_edit(p.name), [chk_support(p.type)])
                      for p in model_desc_pre.response.nonlocparams]
     return Node('root', None, False, [], [
-        Node('b',    Prior(('b',),   Cauchy(0., 1.)), False, [chk_support(Type['Real']())],    b_children),
-        Node('sd',   Prior(('sd',),  HalfCauchy(3.)), False, [chk_support(Type['PosReal']())], sd_children),
-        Node('cor',  Prior(('cor',), LKJ(1.)),        False, [chk_lkj],                        cor_children),
-        Node('resp', None,                            False, [],                               resp_children)])
+        Node('b', Prior(('b',), Cauchy(0., 1.)), False, [chk_support(Type['Real']())], b_children),
+        Node('sd', Prior(('sd',), HalfCauchy(3.)), False, [chk_support(Type['PosReal']())], sd_children),
+        Node('cor', Prior(('cor',), LKJ(1.)), False, [chk_lkj], cor_children),
+        Node('resp', None, False, [], resp_children)])
+
 
 def cols2str(cols):
     return ':'.join(cols)
@@ -167,6 +173,7 @@ def customize_prior(tree, priors):
         tree = edit(tree, prior_edit.path,
                     lambda n: Node(n.name, prior_edit, n.is_param, n.checks, n.children))
     return tree
+
 
 # It's important that trees maintain the order of their children, so
 # that coefficients in the prior tree continue to line up with columns
@@ -192,6 +199,7 @@ def build_prior_tree(model_desc_pre, priors, chk=True):
             raise Exception(format_errors(errors))
     return tree
 
+
 # `fill` populates the `prior_edit` and `checks` properties of all
 # nodes in a tree. Each node uses its own `prior_edit` value if set,
 # otherwise the first `prior_edit` value encountered when walking up
@@ -200,14 +208,16 @@ def build_prior_tree(model_desc_pre, priors, chk=True):
 # walking from the node to the root. (This is the behaviour, not the
 # implementation.)
 def fill(node, default=None, upstream_checks=[]):
-    prior = node.prior_edit if not node.prior_edit is None else default
+    prior = node.prior_edit if node.prior_edit is not None else default
     checks = upstream_checks + node.checks
     return Node(node.name, prior, node.is_param, checks, [fill(n, prior, checks) for n in node.children])
+
 
 def leaves(node, path=[]):
     this = [(node, path)] if node.is_param else []
     rest = join(leaves(n, path + [n.name]) for n in node.children)
     return this + rest
+
 
 # Sanity checks
 
@@ -227,10 +237,13 @@ class Chk():
     def __repr__(self):
         return 'Chk("{}")'.format(self.name)
 
+
 def chk(name):
     def decorate(predicate):
         return Chk(predicate, name)
+
     return decorate
+
 
 def chk_support(typ):
     # TODO: This could probably be relaxed to only require that the
@@ -238,11 +251,14 @@ def chk_support(typ):
     # (However this is easier and good enough for now.)
     def pred(prior):
         return prior.support() == typ
+
     return Chk(pred, 'has support of {}'.format(typ))
+
 
 @chk('is LKJ')
 def chk_lkj(prior):
     return prior.name == 'LKJ'
+
 
 def check(tree):
     errors = defaultdict(lambda: defaultdict(list))
@@ -255,11 +271,13 @@ def check(tree):
                 errors[node.prior_edit.path][chk].append(path)
     return errors
 
+
 # TODO: There's info in `errors` which we're not making use of here.
 def format_errors(errors):
     paths = ', '.join('"{}"'.format('/'.join(path))
                       for path in errors.keys())
     return 'Invalid prior specified at {}.'.format(paths)
+
 
 def leaves_without_prior(tree):
     return [path for (node, path) in leaves(tree) if node.prior_edit is None]

--- a/brmp/utils.py
+++ b/brmp/utils.py
@@ -1,11 +1,13 @@
 def join(lists):
     return sum(lists, [])
 
+
 def unzip(pairs):
     if len(pairs) == 0:
         return [], []
     else:
         return zip(*pairs)
+
 
 # Helpers for working with arrays of samples. These work with both
 # numpy and torch arrays.
@@ -13,6 +15,7 @@ def unzip(pairs):
 # (num_chains, num_samples, ...) -> (num_chains * num_samples, ...)
 def flatten(arr):
     return arr.reshape((arr.shape[0] * arr.shape[1],) + arr.shape[2:])
+
 
 # (num_chains * num_samples, ...) -> (num_chains, num_samples, ...)
 def unflatten(arr, num_chains, num_samples):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../..'))
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,6 @@ author = 'brmp authors'
 
 # -- General configuration ---------------------------------------------------
 
-import sphinx_rtd_theme
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -49,7 +48,8 @@ exclude_patterns = []
 
 # https://github.com/readthedocs/sphinx_rtd_theme/issues/117
 def setup(app):
-   app.add_stylesheet('theme_overrides.css')
+    app.add_stylesheet('theme_overrides.css')
+
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -68,4 +68,5 @@ html_static_path = ['_static']
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
                        'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-                       'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),}
+                       'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+                       }

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(name='brmp',
       packages=find_packages(),
@@ -8,5 +8,6 @@ setup(name='brmp',
         'numpyro>=0.2.0',
       ],
       extras_require={
-        'test': ['flake8', 'pytest']
+          'test': ['flake8', 'pytest'],
+          'docs': ['sphinx', 'sphinx-rtd-theme'],
       })

--- a/tests/test_brm.py
+++ b/tests/test_brm.py
@@ -15,12 +15,11 @@ from brmp.design import (Categorical, CategoricalCoding, Integral,
                          NumericCoding, RealValued, code_lengths, code_terms,
                          coef_names, dummy_df, make_column_lookup, makedata,
                          metadata_from_cols, metadata_from_df)
-from brmp.family import (LKJ, Bernoulli, Binomial, HalfCauchy,
-                         HalfNormal, Normal)
+from brmp.family import (LKJ, Bernoulli, Binomial, HalfCauchy, HalfNormal,
+                         Normal)
 from brmp.fit import Samples, fitted, get_param, marginals
 from brmp.formula import Formula, OrderedSet, Term, _1, allfactors, parse
-from brmp.model import (parameters, scalar_parameter_map,
-                        scalar_parameter_names)
+from brmp.model import parameters, scalar_parameter_map, scalar_parameter_names
 from brmp.model_pre import build_model_pre
 from brmp.numpyro_backend import backend as numpyro_backend
 from brmp.priors import Prior, build_prior_tree


### PR DESCRIPTION
There is purely a formatting change. 
 - Adds fixes from flake8;  running `make test` in travis will run the linter.
 - Adds `make docs` and `make lint` commands to the `Makefile`. Note that to reformat imports, we can use `make format`.

@null-a - Since these changes pervade the codebase, we could defer merging if you have any major PRs that you are currently working on, so that you can avoid merge conflicts.

Fixes #5, #36. 