### PR TITLE
Run more tests on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,4 @@ lint: FORCE
 test: lint FORCE
 	pytest -vs tests --tb=short
 
-test-all: lint FORCE
-	RUN_SLOW=1 pytest -vs tests --tb=short
-
 FORCE:

--- a/tests/test_brm.py
+++ b/tests/test_brm.py
@@ -428,21 +428,9 @@ def test_expected_response_codegen(response_meta, family, args, expected, backen
 
 @pytest.mark.parametrize('formula_str, non_real_cols, contrasts, family, priors, expected', codegen_cases)
 @pytest.mark.parametrize('fitargs', [
-    dict(backend=pyro_backend, iter=1, warmup=0),
-    dict(backend=pyro_backend, iter=1, warmup=0, num_chains=2),
-    dict(backend=pyro_backend, algo='svi', iter=1, num_samples=1),
-    dict(backend=pyro_backend, algo='svi', iter=1, num_samples=1, subsample_size=1),
-    # Set environment variable `RUN_SLOW=1` to run against the NumPyro
-    # back end.
-    pytest.param(
-        dict(backend=numpyro_backend, iter=1, warmup=0),
-        marks=pytest.mark.skipif(not os.environ.get('RUN_SLOW', ''), reason='slow')),
-    pytest.param(
-        dict(backend=numpyro_backend, iter=1, warmup=0, num_chains=2),
-        marks=pytest.mark.skipif(not os.environ.get('RUN_SLOW', ''), reason='slow')),
+    dict(backend=pyro_backend, num_samples=1, algo='prior'),
+    dict(backend=numpyro_backend, num_samples=1, algo='prior'),
 ])
-# TODO: Remove on next Pyro release.
-@pytest.mark.xfail('CI' in os.environ, reason='Failure when num_chains > num_cpu; fixed in Pyro master.')
 def test_parameter_shapes(formula_str, non_real_cols, contrasts, family, priors, expected, fitargs):
     # Make dummy data.
     N = 5


### PR DESCRIPTION
This is a minor re-organisation of some tests to improve the coverage we get from CI tests. Previously the tests which exercised the nuts method of the numpyro backend were hidden behind the `RUN_SLOW` flag, and these were not included in CI. I've now dropped this flag.

To keep a lid on the time it takes to run the entire suite, I've reduced the number of tests which use numpyro's `nuts` method. This was achieved by (a) switching to running some "parameter shape" tests using only the `prior` algorithm, and (b) splitting out cases related to "new data" from `test_marginals_and_fitted_smoke`. I think we lose very little by doing this -- I think it's a good trade-off.

Fixes #48.