### PR TITLE
Move methods on to `Fit` class.

### DIFF
--- a/brmp/examples/Africa.ipynb
+++ b/brmp/examples/Africa.ipynb
@@ -19,7 +19,7 @@
     "from pyro.optim import Adam\n",
     "from pyro.contrib.autoguide import AutoIAFNormal\n",
     "from brmp import defm\n",
-    "from brmp.fit import marginals, fitted, summary, get_scalar_param\n",
+    "from brmp.fit import summary\n",
     "from brmp.pyro_backend import backend as pyro_backend\n",
     "from brmp.numpyro_backend import backend as numpyro"
    ]
@@ -271,7 +271,7 @@
     }
    ],
    "source": [
-    "marginals(fit)"
+    "fit.marginals()"
    ]
   },
   {
@@ -379,9 +379,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use the `fitted` function to compute the posterior distribution over the expected response for each data point in our new data set.\n",
+    "We can use the `fitted` method to compute the posterior distribution over the expected response for each data point in our new data set.\n",
     "\n",
-    "(`summary(fitted(fit, data=...))` is analogous to `fitted(fit, newdata=..., summary=TRUE)` in brms.)"
+    "(`summary(fit.fitted(data=...))` is analogous to `fitted(fit, newdata=..., summary=TRUE)` in brms.)"
    ]
   },
   {
@@ -527,7 +527,7 @@
     }
    ],
    "source": [
-    "smry = summary(fitted(fit, data=nd))\n",
+    "smry = summary(fit.fitted(data=nd))\n",
     "assert len(nd) == smry.array.shape[0] # there is one row in the summary for each row of the new data set\n",
     "smry # TODO: It would be good to be able to index this (directly, not via `array`) while retaining the __repr__"
    ]
@@ -633,7 +633,7 @@
     }
    ],
    "source": [
-    "smry2 = summary(fitted(fit, what='sample', data=nd))\n",
+    "smry2 = summary(fit.fitted(what='sample', data=nd))\n",
     "#smry2\n",
     "plot_fitted_summary(nd, smry2, 0)\n",
     "plot_fitted_summary(nd, smry2, 1)"
@@ -678,7 +678,7 @@
    ],
    "source": [
     "nd2 = make_new_data(-10., 16., 0.5)\n",
-    "smry3 = summary(fitted(fit, what='sample', data=nd2))\n",
+    "smry3 = summary(fit.fitted(what='sample', data=nd2))\n",
     "plot_fitted_summary(nd2, smry3, 0)\n",
     "plot_fitted_summary(nd2, smry3, 1)"
    ]
@@ -694,7 +694,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For African countries (rows in which `cont_africa=1`) the slope of the regression line is given by `rugged + rugged:cont_africa[1]`. For other countries the slope is simply `rugged`. Here we extract these values from the posterior samples using the `get_scalar_param` helper. (This acccepts as input those parameter names that appear in the output of `marginals(fit)` above, and returns a vector with length equal to the number of samples collected during inference.)"
+    "For African countries (rows in which `cont_africa=1`) the slope of the regression line is given by `rugged + rugged:cont_africa[1]`. For other countries the slope is simply `rugged`. Here we extract these values from the posterior samples using the `get_scalar_param` method. (This acccepts as input those parameter names that appear in the output of `fit.marginals()` above, and returns a vector with length equal to the number of samples collected during inference.)"
    ]
   },
   {
@@ -703,8 +703,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rugged = get_scalar_param(fit, 'b_rugged')\n",
-    "rugged_cont_africa = get_scalar_param(fit, 'b_rugged:cont_africa[1]')\n",
+    "rugged = fit.get_scalar_param('b_rugged')\n",
+    "rugged_cont_africa = fit.get_scalar_param('b_rugged:cont_africa[1]')\n",
     "gamma_africa = rugged + rugged_cont_africa\n",
     "gamma_not_africa = rugged"
    ]

--- a/brmp/examples/Baseball.ipynb
+++ b/brmp/examples/Baseball.ipynb
@@ -18,7 +18,7 @@
     "import pandas as pd\n",
     "from brmp import defm\n",
     "from brmp.priors import Prior\n",
-    "from brmp.fit import marginals, print_model, fitted, summary\n",
+    "from brmp.fit import summary\n",
     "from brmp.family import Normal, HalfNormal, Binomial\n",
     "from brmp.numpyro_backend import backend as numpyro"
    ]
@@ -286,14 +286,14 @@
     }
    ],
    "source": [
-    "marginals(fit)"
+    "fit.marginals()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we recreate the plot of model predictions vs. the true remaining batting average. (Compare with the right-most plot in [this image](https://solomonkurz.netlify.com/post/2019-02-23-stein-s-paradox-and-what-partial-pooling-can-do-for-you_files/figure-html/unnamed-chunk-24-1.png).) This appears similar to the plot in the blog post. (Though note that we have different data for player Williams, as mentioned earlier.) This makes use of the `fitted` function which is analogous to the [`fitted`](https://rdrr.io/cran/brms/man/fitted.brmsfit.html) method in brms."
+    "Here we recreate the plot of model predictions vs. the true remaining batting average. (Compare with the right-most plot in [this image](https://solomonkurz.netlify.com/post/2019-02-23-stein-s-paradox-and-what-partial-pooling-can-do-for-you_files/figure-html/unnamed-chunk-24-1.png).) This appears similar to the plot in the blog post. (Though note that we have different data for player Williams, as mentioned earlier.) This makes use of the `fitted` method which is analogous to the [`fitted`](https://rdrr.io/cran/brms/man/fitted.brmsfit.html) method in brms."
    ]
   },
   {
@@ -315,7 +315,7 @@
     }
    ],
    "source": [
-    "sampled_probs = fitted(fit, 'response')\n",
+    "sampled_probs = fit.fitted('response')\n",
     "tups = sorted(zip(df['RemainingAverage'], df['Player'], sampled_probs.T))\n",
     "avg, labels, samples = zip(*tups)\n",
     "xlim((0.0, 0.55))\n",

--- a/brmp/fit.py
+++ b/brmp/fit.py
@@ -34,13 +34,13 @@ class Fit(namedtuple('Fit', 'formula metadata contrasts data model_desc model sa
 
     # brms                                               | brmp
     # -----------------------------------------------------------------------------------
-    # fitted(fit, summary=FALSE)                         | fitted(fit)
-    # fitted(dpar='mu', scale='linear', summary=FALSE)   | fitted(fit, 'linear')
-    # fitted(dpar='mu', scale='response', summary=FALSE) | fitted(fit, 'response')
-    # fitted(fit, newdata=..., summary=FALSE)            | fitted(fit, data=...)
-    # fitted(fit, ..., summary=TRUE)                     | summary(fitted(fit, ...))
-    # predict(fit, summary=FALSE)                        | fitted(fit, 'sample')
-    # predict(fit, summary=TRUE)                         | summary(fitted(fit, 'sample'))
+    # fitted(fit, summary=FALSE)                         | fit.fitted()
+    # fitted(dpar='mu', scale='linear', summary=FALSE)   | fit.fitted('linear')
+    # fitted(dpar='mu', scale='response', summary=FALSE) | fit.fitted('response')
+    # fitted(fit, newdata=..., summary=FALSE)            | fit.fitted(data=...)
+    # fitted(fit, ..., summary=TRUE)                     | summary(fit.fitted(...))
+    # predict(fit, summary=FALSE)                        | fit.fitted('sample')
+    # predict(fit, summary=TRUE)                         | summary(fit.fitted('sample'))
 
     # https://rdrr.io/cran/brms/man/fitted.brmsfit.html
 

--- a/docs/source/fit.rst
+++ b/docs/source/fit.rst
@@ -2,9 +2,5 @@ Fit
 ===
 
 .. autoclass:: brmp.fit.Fit
-
-.. autofunction:: brmp.fit.marginals
-
-.. autofunction:: brmp.fit.fitted
-
-.. autofunction:: brmp.fit.get_scalar_param
+    :members:
+    :member-order: bysource


### PR DESCRIPTION
This moves `marginals`, `fitted` etc. from top-level methods to methods on the `Fit` class. (Closes #50.)

I'm personally happy with either approach, but I'm guessing the change is worth making since the result is arguably more idiomatic. Agreed?