### PR TITLE
Add requirements.txt for doc generation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+sphinx
+sphinx_rtd_theme
+pandas
+pyro-ppl>=0.4.1
+numpyro>=0.2.0'


### PR DESCRIPTION
This is needed to publish the docs on readthedocs. 

cc @jpchen - let me know if we need to make any changes.