### PR TITLE
Support a `seed` argument across all inference methods.

### DIFF
--- a/brmp/__init__.py
+++ b/brmp/__init__.py
@@ -169,12 +169,14 @@ class GenerateResult():
         return Fit(self.defm_result.formula, self.defm_result.metadata, self.defm_result.contrasts, self.data,
                    self.defm_result.desc, self.model, samples, self.backend)
 
-    def prior(self, num_samples=10, *args, **kwargs):
+    def prior(self, num_samples=10, seed=None, *args, **kwargs):
         """
         Sample from the prior.
 
         :param num_samples: The number of samples to take.
         :type num_samples: int
+        :param seed: Random seed.
+        :type seed: int
         :return: A model fit.
         :rtype: brmp.fit.Fit
 
@@ -183,9 +185,9 @@ class GenerateResult():
           fit = defm('y ~ x', df).generate().prior()
 
         """
-        return self._run_algo('prior', num_samples, *args, **kwargs)
+        return self._run_algo('prior', num_samples, seed, *args, **kwargs)
 
-    def nuts(self, iter=10, warmup=None, num_chains=1, *args, **kwargs):
+    def nuts(self, iter=10, warmup=None, num_chains=1, seed=None, *args, **kwargs):
         """
         Fit the model using NUTS.
 
@@ -197,6 +199,8 @@ class GenerateResult():
         :type warmup: int
         :param num_chains: The number of chains to run.
         :type num_chains: int
+        :param seed: Random seed.
+        :type seed: int
         :return: A model fit.
         :rtype: brmp.fit.Fit
 
@@ -206,9 +210,9 @@ class GenerateResult():
 
         """
         warmup = iter // 2 if warmup is None else warmup
-        return self._run_algo('nuts', iter, warmup, num_chains, *args, **kwargs)
+        return self._run_algo('nuts', iter, warmup, num_chains, seed, *args, **kwargs)
 
-    def svi(self, iter=10, num_samples=10, *args, **kwargs):
+    def svi(self, iter=10, num_samples=10, seed=None, *args, **kwargs):
         """
         Fit the model using stochastic variational inference.
 
@@ -217,6 +221,8 @@ class GenerateResult():
         :param num_samples: The number of samples to take from the variational
                             posterior.
         :type num_samples: int
+        :param seed: Random seed.
+        :type seed: int
         :return: A model fit.
         :rtype: brmp.fit.Fit
 
@@ -225,4 +231,4 @@ class GenerateResult():
           fit = defm('y ~ x', df).generate().svi()
 
         """
-        return self._run_algo('svi', iter, num_samples, *args, **kwargs)
+        return self._run_algo('svi', iter, num_samples, seed, *args, **kwargs)

--- a/brmp/numpyro_backend.py
+++ b/brmp/numpyro_backend.py
@@ -14,6 +14,10 @@ from brmp.utils import flatten, unflatten
 config.update("jax_platform_name", "cpu")
 
 
+def sample_rng_seed():
+    return np.random.randint(0, 2 ** 32, dtype=np.uint32).astype(np.int32)
+
+
 # The types described in the comments in pyro_backend.py as follows
 # in this back end:
 #
@@ -64,7 +68,7 @@ def location(original_data, samples, transformed_samples, model_fn, new_data):
         return flatten(run_model_on_samples_and_data(model_fn, samples, new_data)['mu'])
 
 
-def nuts(data, model, iter, warmup, num_chains, seed=None):
+def nuts(data, model, iter, warmup, num_chains, seed):
     assert type(data) == dict
     assert type(model) == Model
     assert type(iter) == int
@@ -73,7 +77,7 @@ def nuts(data, model, iter, warmup, num_chains, seed=None):
     assert seed is None or type(seed) == int
 
     if seed is None:
-        seed = np.random.randint(0, 2 ** 32, dtype=np.uint32).astype(np.int32)
+        seed = sample_rng_seed()
     rng = random.PRNGKey(seed)
 
     kernel = NUTS(model.fn)
@@ -99,14 +103,14 @@ def svi(*args, **kwargs):
     raise NotImplementedError
 
 
-def prior(data, model, num_samples, seed=None):
+def prior(data, model, num_samples, seed):
     assert type(data) == dict
     assert type(model) == Model
     assert type(num_samples) == int and num_samples > 0
     assert seed is None or type(seed) == int
 
     if seed is None:
-        seed = np.random.randint(0, 2 ** 32, dtype=np.uint32).astype(np.int32)
+        seed = sample_rng_seed()
     rngs = random.split(random.PRNGKey(seed), num_samples)
 
     def get_model_trace(rng):

--- a/brmp/pyro_backend.py
+++ b/brmp/pyro_backend.py
@@ -1,7 +1,7 @@
 import time
 from functools import partial
 from sys import stderr
-from contextlib import nullcontext
+from contextlib import contextmanager
 
 import numpy as np
 import torch
@@ -17,6 +17,12 @@ from pyro.infer.autoguide import AutoMultivariateNormal
 from pyro.infer.mcmc import NUTS
 from pyro.infer.mcmc.api import MCMC
 from pyro.optim import Adam
+
+
+# Available as `contextmanager.nullcontext` in Python 3.7
+@contextmanager
+def nullcontext(enter_result=None):
+    yield enter_result
 
 
 # A wrapper around the Pyro seed handler, providing handling for the


### PR DESCRIPTION
The numpyro methods `nuts` and `prior` currently take a `seed` argument, which does the obvious thing. This PR adds a similar argument to the pyro methods `nuts`, `svi` and `prior`. This argument is now available uniformly across inference methods, and I've updated the docs to reflect this. This PR also adds some basic tests.

(Partially addresses #11.)