### PR TITLE
Allow rng seed to be given to `fit.fitted(what='sample')`.

### DIFF
--- a/brmp/numpyro_backend.py
+++ b/brmp/numpyro_backend.py
@@ -134,9 +134,13 @@ def prior(data, model, num_samples, seed):
 
 # This particular back end implements this by generating additional
 # code but other approaches are possible.
-def sample_response(model, *args):
+def sample_response(model, seed, *args):
     assert type(model) == Model
-    return model.sample_response_fn(*args)
+    assert seed is None or type(seed) is int
+    if seed is None:
+        seed = sample_rng_seed()
+    rng = random.PRNGKey(seed)
+    return handler.seed(model.sample_response_fn, rng)(*args)
 
 
 def expected_response(model, *args):

--- a/brmp/numpyro_codegen.py
+++ b/brmp/numpyro_codegen.py
@@ -1,9 +1,5 @@
 import re
 
-import numpy as np
-from jax import random
-from numpyro.handlers import seed
-
 from brmp.backend import Model
 from brmp.family import Family, LinkFn, Normal, args, free_param_names
 from brmp.model import Group, ModelDesc
@@ -359,12 +355,8 @@ def gen(model_desc):
     inv_link_fn = eval_method(inv_link_code)
     expected_response_code = gen_response_fn(model_desc, mode='expectation')
     expected_response_fn = eval_method(expected_response_code)
-    # TODO: Give the use control over the seed used here. Ideally do
-    # something that works uniformly across back ends.
-    rng_seed = np.random.randint(0, 2 ** 32, dtype=np.uint32).astype(np.int32)
-    rng = random.PRNGKey(rng_seed)
     sample_response_code = gen_response_fn(model_desc, mode='sample')
-    sample_response_fn = seed(eval_method(sample_response_code), rng)
+    sample_response_fn = eval_method(sample_response_code)
     return Model(fn, code,
                  inv_link_fn, inv_link_code,
                  expected_response_fn, expected_response_code,

--- a/brmp/pyro_backend.py
+++ b/brmp/pyro_backend.py
@@ -291,9 +291,11 @@ def prior(data, model, num_samples, seed):
 
 # This particular back end implements this by generating additional
 # code but other approaches are possible.
-def sample_response(model, *args):
+def sample_response(model, seed, *args):
     assert type(model) == Model
-    return model.sample_response_fn(*args)
+    assert seed is None or type(seed) is int
+    with seed_ctx_mgr(seed):
+        return model.sample_response_fn(*args)
 
 
 def expected_response(model, *args):

--- a/tests/test_brm.py
+++ b/tests/test_brm.py
@@ -1126,3 +1126,8 @@ def test_rng_seed(fitargs):
     fit2 = model.fit(seed=1, **fitargs)
     assert (fit0.fitted() == fit1.fitted()).all()
     assert not (fit1.fitted() == fit2.fitted()).all()
+    fitted0 = fit0.fitted(what='sample', seed=0)
+    fitted1 = fit0.fitted(what='sample', seed=0)
+    fitted2 = fit0.fitted(what='sample', seed=1)
+    assert (fitted0 == fitted1).all()
+    assert not (fitted1 == fitted2).all()


### PR DESCRIPTION
Closes #11.

BTW, this is where #61 was useful. Because we're now not calling the generated `sample_response_fn` directly (e.g. from `fitted`), back ends have the opportunity to apply the seed handler to the generated code.