### PR TITLE
Fix RTD build by using small sized CPU wheels for PyTorch

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 sphinx_rtd_theme
 pandas
+pip -f https://download.pytorch.org/whl/torch_stable.html torch==1.3.0+cpu
 pyro-ppl>=0.5.1
 numpyro>=0.2.0'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,11 @@ exclude_patterns = []
 def setup(app):
     app.add_stylesheet('theme_overrides.css')
 
+# source_suffix = ['.rst', '.md']
+source_suffix = '.rst'
+
+# The master toctree document.
+master_doc = 'index'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,7 @@ exclude_patterns = []
 def setup(app):
     app.add_stylesheet('theme_overrides.css')
 
+
 # source_suffix = ['.rst', '.md']
 source_suffix = '.rst'
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,3 +71,7 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
                        'numpy': ('http://docs.scipy.org/doc/numpy/', None),
                        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
                        }
+
+# XXX: Use small sized CPU wheels for rtd builder
+if 'READTHEDOCS' in os.environ:
+    os.system('pip install torch==1.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,3 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
                        'numpy': ('http://docs.scipy.org/doc/numpy/', None),
                        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
                        }
-
-# XXX: Use small sized CPU wheels for rtd builder
-if 'READTHEDOCS' in os.environ:
-    os.system('pip install torch==1.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html')


### PR DESCRIPTION
Addresses #4 - getting RTD build to work correctly for brmp. [link](https://brmp.readthedocs.io/en/fix-build/) to docs for the built branch.