### PR TITLE
Interface changes

### DIFF
--- a/brmp/design.py
+++ b/brmp/design.py
@@ -564,7 +564,7 @@ def execute_product_col(product_col, df, metadata, contrasts):
             levels = metadata.column(col.factor).levels
             # TODO: This can be triggered in normal use, so turn into
             # friendly error. It probably makes sense to check for
-            # this earlier. This could possibly happen in `defm` after
+            # this earlier. This could possibly happen in `brm` after
             # creating the metadata, though this would also require a
             # separate check for SequentialOED. Is there anywhere
             # sensible to put this that catches both?

--- a/brmp/examples/Africa.ipynb
+++ b/brmp/examples/Africa.ipynb
@@ -18,7 +18,7 @@
     "import pandas as pd\n",
     "from pyro.optim import Adam\n",
     "from pyro.contrib.autoguide import AutoIAFNormal\n",
-    "from brmp import defm\n",
+    "from brmp import brm\n",
     "from brmp.fit import summary\n",
     "from brmp.pyro_backend import backend as pyro_backend\n",
     "from brmp.numpyro_backend import backend as numpyro"
@@ -183,7 +183,7 @@
    ],
    "source": [
     "# eqv. to `1 + rugged*cont_africa` (the * operator is not yet supported)\n",
-    "model = defm('log_gdp ~ 1 + rugged + cont_africa + rugged:cont_africa', df)\n",
+    "model = brm('log_gdp ~ 1 + rugged + cont_africa + rugged:cont_africa', df)\n",
     "model"
    ]
   },

--- a/brmp/examples/Baseball.ipynb
+++ b/brmp/examples/Baseball.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "%pylab inline\n",
     "import pandas as pd\n",
-    "from brmp import defm\n",
+    "from brmp import brm\n",
     "from brmp.priors import Prior\n",
     "from brmp.fit import summary\n",
     "from brmp.family import Normal, HalfNormal, Binomial\n",
@@ -179,7 +179,7 @@
     }
    ],
    "source": [
-    "model = defm(\n",
+    "model = brm(\n",
     "    'Hits ~ 1 + (1 | Player)',\n",
     "    df,\n",
     "    # Response family:\n",

--- a/brmp/examples/Priors.ipynb
+++ b/brmp/examples/Priors.ipynb
@@ -9,7 +9,7 @@
     "import difflib\n",
     "from IPython.core.display import display, HTML\n",
     "import pandas as pd\n",
-    "from brmp import defm\n",
+    "from brmp import brm\n",
     "from brmp.priors import Prior\n",
     "from brmp.family import Normal, HalfNormal"
    ]
@@ -89,7 +89,7 @@
     }
    ],
    "source": [
-    "default_model = defm(formula, df)\n",
+    "default_model = brm(formula, df)\n",
     "print(default_model)"
    ]
   },
@@ -215,7 +215,7 @@
    ],
    "source": [
     "# Specify priors for all population level coefs.\n",
-    "model = defm(formula, df, priors=[Prior(('b',), Normal(0.,10.))])\n",
+    "model = brm(formula, df, priors=[Prior(('b',), Normal(0.,10.))])\n",
     "diff_with_default(model)"
    ]
   },
@@ -322,7 +322,7 @@
    ],
    "source": [
     "# Specify prior for a particular population level coef.\n",
-    "model = defm(formula, df, priors=[Prior(('b', 'intercept'), Normal(0.,10.))])\n",
+    "model = brm(formula, df, priors=[Prior(('b', 'intercept'), Normal(0.,10.))])\n",
     "diff_with_default(model)"
    ]
   },
@@ -434,7 +434,7 @@
    ],
    "source": [
     "# Specify all std. dev. priors for all groups.\n",
-    "model = defm(formula, df, priors=[Prior(('sd',), HalfNormal(10.))])\n",
+    "model = brm(formula, df, priors=[Prior(('sd',), HalfNormal(10.))])\n",
     "diff_with_default(model)"
    ]
   },
@@ -539,7 +539,7 @@
    ],
    "source": [
     "# Specify std. dev. for a whole group.\n",
-    "model = defm(formula, df, priors=[Prior(('sd', 'a'), HalfNormal(10.))])\n",
+    "model = brm(formula, df, priors=[Prior(('sd', 'a'), HalfNormal(10.))])\n",
     "diff_with_default(model)"
    ]
   },
@@ -644,7 +644,7 @@
    ],
    "source": [
     "# Specify std. dev. for a particular coef in a particular group.\n",
-    "model = defm(formula, df, priors=[Prior(('sd', 'a', 'intercept'), HalfNormal(10.))])\n",
+    "model = brm(formula, df, priors=[Prior(('sd', 'a', 'intercept'), HalfNormal(10.))])\n",
     "diff_with_default(model)"
    ]
   },
@@ -755,7 +755,7 @@
     }
    ],
    "source": [
-    "model = defm(formula, df, priors=[Prior(('resp', 'sigma'), HalfNormal(10.))])\n",
+    "model = brm(formula, df, priors=[Prior(('resp', 'sigma'), HalfNormal(10.))])\n",
     "diff_with_default(model)"
    ]
   },

--- a/brmp/fit.py
+++ b/brmp/fit.py
@@ -132,7 +132,7 @@ class Fit(namedtuple('Fit', 'formula metadata contrasts data model_desc model sa
 
         Example::
 
-          fit = defm('y ~ x', df).fit()
+          fit = brm('y ~ x', df).fit()
           print(fit.marginals())
 
           #        mean    sd  2.5%   25%   50%   75% 97.5% n_eff r_hat

--- a/brmp/priors.py
+++ b/brmp/priors.py
@@ -37,7 +37,7 @@ Prior = namedtuple('Prior', 'path prior')
 
 A :class:`~brmp.prior.Prior` instance associates a prior distribution with one
 or more parameters of a model. One or more such instances may be passed to
-:func:`~brmp.defm` to override its default choice of priors.
+:func:`~brmp.brm` to override its default choice of priors.
 
 The parameters of the model to which a prior should be applied are specified
 using a path. The following examples illustrate how this works:

--- a/docs/source/brmp.rst
+++ b/docs/source/brmp.rst
@@ -1,12 +1,8 @@
 brmp
 ====
 
-.. autofunction:: brmp.defm
+.. autofunction:: brmp.brm
 
-.. autoclass:: brmp.DefmResult
-    :members:
-    :member-order: bysource
-
-.. autoclass:: brmp.GenerateResult
+.. autoclass:: brmp.ModelAndData
     :members:
     :member-order: bysource


### PR DESCRIPTION
The aim of this PR is to (a) simplify the public interface for defining models and running inference (partially addressing #32), and (b) to introduce a new interface (for the same purpose) that is less convenient but more flexible.

The main change to the public interface is that there is no longer an explicit `generate` step when defining a model. A further minor change is that `defm` is renamed to `brm`. For example:

```python
# before
fit = defm('y ~ x', df).generate(numpyro).fit(algo='nuts', iter=10)
# after
fit = brm('y ~ x', df).fit(algo='nuts', iter=10, backend=numpyro)
# alternatively
fit = brm('y ~ x', df).nuts(iter=10, backend=numpyro)
```

While it was already possible to avoid explicitly calling `generate`, its presence in the docs makes things seem a bit more complicated than they need to be. I think this change helps make things quite a bit clearer. Comparing the docs before and after this PR shows this I think.

The downside to this change is that we lose some (less frequently used) functionality. e.g. It's no longer possible to inspect the generated model code without first fitting the model. However, the new (currently private/undocumented) interface facilitates this and more. Typical usage:

```python
model = define_model('y ~ x', metadata).gen(numpyro)
data = model.encode(df)
fit = model.run_algo('nuts', data, iter=10)
```

The addition of this extra interface was motivated by the OED branch, where it's useful to have a convenient way to (a) define a model before collecting data (`define_model`) , and (b) to run inference multiple times on different data. (I imagine this could also be used to simplify some tests -- I'll look at a making a follow-up PR for that.)

There's likely room to improve this over time, but heading in this general direction seems OK to me. What do you think?



