### PR TITLE
Adjust default backends

### DIFF
--- a/brmp/__init__.py
+++ b/brmp/__init__.py
@@ -10,8 +10,7 @@ from brmp.model import build_model, model_repr
 from brmp.model_pre import build_model_pre
 from brmp.priors import build_prior_tree
 from brmp.pyro_backend import backend as pyro_backend
-
-_default_backend = pyro_backend
+from brmp.numpyro_backend import backend as numpyro_backend
 
 
 def makedesc(formula, metadata, family, priors, code_lengths):
@@ -175,7 +174,7 @@ class ModelAndData:
         assert algo in ['prior', 'nuts', 'svi']
         return getattr(self, algo)(**kwargs)
 
-    def nuts(self, iter=10, warmup=None, num_chains=1, seed=None, backend=None):
+    def nuts(self, iter=10, warmup=None, num_chains=1, seed=None, backend=numpyro_backend):
         """
         Fit the model using NUTS.
 
@@ -200,11 +199,9 @@ class ModelAndData:
 
         """
         warmup = iter // 2 if warmup is None else warmup
-        if backend is None:
-            backend = _default_backend
         return self.run_algo('nuts', backend, iter, warmup, num_chains, seed)
 
-    def svi(self, iter=10, num_samples=10, seed=None, backend=None, **kwargs):
+    def svi(self, iter=10, num_samples=10, seed=None, backend=pyro_backend, **kwargs):
         """
         Fit the model using stochastic variational inference.
 
@@ -225,11 +222,9 @@ class ModelAndData:
           fit = brm('y ~ x', df).svi()
 
         """
-        if backend is None:
-            backend = _default_backend
         return self.run_algo('svi', backend, iter, num_samples, seed, **kwargs)
 
-    def prior(self, num_samples=10, seed=None, backend=None):
+    def prior(self, num_samples=10, seed=None, backend=pyro_backend):
         """
         Sample from the prior.
 
@@ -248,8 +243,6 @@ class ModelAndData:
           fit = brm('y ~ x', df).prior()
 
         """
-        if backend is None:
-            backend = _default_backend
         return self.run_algo('prior', backend, num_samples, seed)
 
     def __repr__(self):

--- a/brmp/backend.py
+++ b/brmp/backend.py
@@ -88,9 +88,11 @@ from collections import namedtuple
 # rather than the expected value.
 
 
-Backend = namedtuple('Backend', 'name gen prior nuts svi ' +
-                     'sample_response expected_response inv_link ' +
-                     'from_numpy to_numpy')
+class Backend(namedtuple('Backend', 'name gen prior nuts svi ' +
+                         'sample_response expected_response inv_link ' +
+                         'from_numpy to_numpy')):
+    def __repr__(self):
+        return '<Backend name="{}">'.format(self.name)
 
 
 # Map `from_numpy` over a dict of numpy arrays, (As produced by e.g.

--- a/tests/test_brm.py
+++ b/tests/test_brm.py
@@ -1101,7 +1101,7 @@ def test_fitted_on_new_data(N2):
     contrasts = {'a': np.array([[-1, -1], [1, 1]])}
     cols = expand_columns(parse(formula_str), [Categorical('a', ['a0', 'a1'])])
     df = dummy_df(cols, N)
-    fit = brm(formula_str, df, Normal, contrasts=contrasts).fit(iter=S)
+    fit = brm(formula_str, df, Normal, contrasts=contrasts).fit(iter=S, backend=pyro_backend)
     new_data = dummy_df(cols, N2, allow_non_exhaustive=True)
     arr = fit.fitted(data=new_data)
     assert np.all(np.isfinite(arr))


### PR DESCRIPTION
This PR makes NumPyro the default backend when using NUTS to fit a model. (Closes #55.)

(I changed the `__repr__` method on `Backend` to make the docs a little nicer to read where a `Backend` appears as a default argument.)