### PR TITLE
Rename some things

### DIFF
--- a/brmp/__init__.py
+++ b/brmp/__init__.py
@@ -56,14 +56,14 @@ class Model:
 
     def gen(self, backend):
         assets = backend.gen(self.desc)
-        return GenResult(self, assets, backend)
+        return AssetsWrapper(self, assets, backend)
 
     # Generate design matrices. (Represented as numpy arrays.)
     def encode(self, df):
         return makedata(self.formula, df, self.metadata, self.contrasts)
 
 
-class GenResult:
+class AssetsWrapper:
     def __init__(self, model, assets, backend):
         assert type(backend) == Backend
         self.model = model
@@ -153,8 +153,8 @@ class ModelAndData:
     def run_algo(self, name, backend, *args, df=None, **kwargs):
         assert type(backend) == Backend
         data = self.model.encode(df) if df is not None else self.data
-        gen_result = self.model.gen(backend)
-        return gen_result.run_algo(name, data_from_numpy(backend, data), *args, **kwargs)
+        assets_wrapper = self.model.gen(backend)
+        return assets_wrapper.run_algo(name, data_from_numpy(backend, data), *args, **kwargs)
 
     def fit(self, algo='nuts', **kwargs):
         """

--- a/brmp/__init__.py
+++ b/brmp/__init__.py
@@ -55,8 +55,8 @@ class DefineModelResult:
         self.desc = desc
 
     def gen(self, backend):
-        model = backend.gen(self.desc)
-        return GenResult(self, model, backend)
+        assets = backend.gen(self.desc)
+        return GenResult(self, assets, backend)
 
     # Generate design matrices. (Represented as numpy arrays.)
     def encode(self, df):
@@ -64,10 +64,10 @@ class DefineModelResult:
 
 
 class GenResult:
-    def __init__(self, define_model_result, model, backend):
+    def __init__(self, define_model_result, assets, backend):
         assert type(backend) == Backend
         self.define_model_result = define_model_result
-        self.model = model
+        self.assets = assets
         self.backend = backend
 
     def encode(self, df):
@@ -75,10 +75,10 @@ class GenResult:
         return data_from_numpy(self.backend, data)
 
     def run_algo(self, name, data, *args, **kwargs):
-        samples = getattr(self.backend, name)(data, self.model, *args, **kwargs)
+        samples = getattr(self.backend, name)(data, self.assets, *args, **kwargs)
         return Fit(self.define_model_result.formula, self.define_model_result.metadata,
                    self.define_model_result.contrasts, data,
-                   self.define_model_result.desc, self.model, samples, self.backend)
+                   self.define_model_result.desc, self.assets, samples, self.backend)
 
 
 def brm(formula_str, df, family=None, priors=None, contrasts=None):

--- a/brmp/__init__.py
+++ b/brmp/__init__.py
@@ -44,10 +44,10 @@ def define_model(formula_str, metadata, family=None, priors=None, contrasts=None
 
     formula = parse(formula_str)
     desc = makedesc(formula, metadata, family, priors, code_lengths(contrasts))
-    return DefineModelResult(formula, metadata, contrasts, desc)
+    return Model(formula, metadata, contrasts, desc)
 
 
-class DefineModelResult:
+class Model:
     def __init__(self, formula, metadata, contrasts, desc):
         self.formula = formula
         self.metadata = metadata
@@ -64,21 +64,21 @@ class DefineModelResult:
 
 
 class GenResult:
-    def __init__(self, define_model_result, assets, backend):
+    def __init__(self, model, assets, backend):
         assert type(backend) == Backend
-        self.define_model_result = define_model_result
+        self.model = model
         self.assets = assets
         self.backend = backend
 
     def encode(self, df):
-        data = self.define_model_result.encode(df)
+        data = self.model.encode(df)
         return data_from_numpy(self.backend, data)
 
     def run_algo(self, name, data, *args, **kwargs):
         samples = getattr(self.backend, name)(data, self.assets, *args, **kwargs)
-        return Fit(self.define_model_result.formula, self.define_model_result.metadata,
-                   self.define_model_result.contrasts, data,
-                   self.define_model_result.desc, self.assets, samples, self.backend)
+        return Fit(self.model.formula, self.model.metadata,
+                   self.model.contrasts, data,
+                   self.model.desc, self.assets, samples, self.backend)
 
 
 def brm(formula_str, df, family=None, priors=None, contrasts=None):
@@ -119,14 +119,14 @@ def brm(formula_str, df, family=None, priors=None, contrasts=None):
     assert priors is None or type(priors) == list
     assert contrasts is None or type(contrasts) == dict
     metadata = metadata_from_df(df)
-    define_model_result = define_model(formula_str, metadata, family, priors, contrasts)
-    data = define_model_result.encode(df)
-    return ModelAndData(define_model_result, df, data)
+    model = define_model(formula_str, metadata, family, priors, contrasts)
+    data = model.encode(df)
+    return ModelAndData(model, df, data)
 
 
 class ModelAndData:
-    def __init__(self, define_model_result, df, data):
-        self.define_model_result = define_model_result
+    def __init__(self, model, df, data):
+        self.model = model
         self.df = df
         # TODO: Turn this into a `@property` to improve generate docs?
         self.data = data
@@ -152,8 +152,8 @@ class ModelAndData:
 
     def run_algo(self, name, backend, *args, df=None, **kwargs):
         assert type(backend) == Backend
-        data = self.define_model_result.encode(df) if df is not None else self.data
-        gen_result = self.define_model_result.gen(backend)
+        data = self.model.encode(df) if df is not None else self.data
+        gen_result = self.model.gen(backend)
         return gen_result.run_algo(name, data_from_numpy(backend, data), *args, **kwargs)
 
     def fit(self, algo='nuts', **kwargs):
@@ -253,4 +253,4 @@ class ModelAndData:
         return self.run_algo('prior', backend, num_samples, seed)
 
     def __repr__(self):
-        return model_repr(self.define_model_result.desc)
+        return model_repr(self.model.desc)

--- a/brmp/backend.py
+++ b/brmp/backend.py
@@ -104,7 +104,7 @@ def data_from_numpy(backend, data):
 # We could have a class that wraps a (function, code) pair, making the
 # code available via a code property and the function available via
 # __call__. `Model` could also be callable. Too cute?
-Model = namedtuple('Model', [
+Assets = namedtuple('Assets', [
     'fn', 'code',
     'inv_link_fn', 'inv_link_code',
     'expected_response_fn', 'expected_response_code',

--- a/brmp/examples/Baseball.ipynb
+++ b/brmp/examples/Baseball.ipynb
@@ -376,7 +376,7 @@
     }
    ],
    "source": [
-    "print(fit.model.code)"
+    "print(fit.assets.code)"
    ]
   },
   {

--- a/brmp/fit.py
+++ b/brmp/fit.py
@@ -28,7 +28,7 @@ default_quantiles = [0.025, 0.25, 0.5, 0.75, 0.975]
 # having to give contrasts has a similar benefit.
 
 
-class Fit(namedtuple('Fit', 'formula metadata contrasts data model_desc model samples backend')):
+class Fit(namedtuple('Fit', 'formula metadata contrasts data model_desc assets samples backend')):
 
     # TODO: This doesn't match the brms interface, but the deviation
     # aren't improvements either. Figure out what to do about that.
@@ -89,9 +89,9 @@ class Fit(namedtuple('Fit', 'formula metadata contrasts data model_desc model sa
         get_param = self.samples.get_param
         location = self.samples.location
         to_numpy = self.backend.to_numpy
-        expected_response = partial(self.backend.expected_response, self.model)
-        sample_response = partial(self.backend.sample_response, self.model, seed)
-        inv_link = partial(self.backend.inv_link, self.model)
+        expected_response = partial(self.backend.expected_response, self.assets)
+        sample_response = partial(self.backend.sample_response, self.assets, seed)
+        inv_link = partial(self.backend.inv_link, self.assets)
 
         mu = location(self.data if data is None
                       else data_from_numpy(self.backend, predictors(self.formula, data, self.metadata, self.contrasts)))

--- a/brmp/numpyro_codegen.py
+++ b/brmp/numpyro_codegen.py
@@ -1,6 +1,6 @@
 import re
 
-from brmp.backend import Model
+from brmp.backend import Assets
 from brmp.family import Family, LinkFn, Normal, args, free_param_names
 from brmp.model import Group, ModelDesc
 from brmp.utils import traceback_generated
@@ -357,7 +357,7 @@ def gen(model_desc):
     expected_response_fn = eval_method(expected_response_code)
     sample_response_code = gen_response_fn(model_desc, mode='sample')
     sample_response_fn = eval_method(sample_response_code)
-    return Model(fn, code,
-                 inv_link_fn, inv_link_code,
-                 expected_response_fn, expected_response_code,
-                 sample_response_fn, sample_response_code)
+    return Assets(fn, code,
+                  inv_link_fn, inv_link_code,
+                  expected_response_fn, expected_response_code,
+                  sample_response_fn, sample_response_code)

--- a/brmp/pyro_codegen.py
+++ b/brmp/pyro_codegen.py
@@ -1,6 +1,6 @@
 import re
 
-from brmp.backend import Model
+from brmp.backend import Assets
 from brmp.family import Family, LinkFn, Normal, args, free_param_names
 from brmp.model import Group, ModelDesc
 from brmp.utils import traceback_generated
@@ -342,7 +342,7 @@ def gen(model_desc):
     expected_response_fn = eval_method(expected_response_code)
     sample_response_code = gen_response_fn(model_desc, mode='sample')
     sample_response_fn = eval_method(sample_response_code)
-    return Model(fn, code,
-                 inv_link_fn, inv_link_code,
-                 expected_response_fn, expected_response_code,
-                 sample_response_fn, sample_response_code)
+    return Assets(fn, code,
+                  inv_link_fn, inv_link_code,
+                  expected_response_fn, expected_response_code,
+                  sample_response_fn, sample_response_code)


### PR DESCRIPTION
This PR (only) renames a few things.

The motivation is to have the new `define_model` method (#68) return a `Model` instance, rather than a `DefineModelResult`. To make this possible I've renamed the existing `Model` class (in `backend.py`) to `Assets`. (`Assets` is just a tuple of Python code/functions generated by a backend, given a model description.)

I've also renamed `GenResult` to `AssetWrapper`. This is much less important than the above, but it seemed a bit nicer to me.