### PR TITLE
Update Pyro to version 1.0

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,4 +20,5 @@ formats: all
 python:
   version: 3.7
   install:
+    - requirements: docs/requirements_torch.txt
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ sphinx
 sphinx_rtd_theme
 pandas
 pip -f https://download.pytorch.org/whl/torch_stable.html torch>=1.3.0+cpu
-pyro-ppl>=0.5.1
+pyro-ppl>=1.0.0
 numpyro>=0.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 sphinx
 sphinx_rtd_theme
 pandas
-pip -f https://download.pytorch.org/whl/torch_stable.html torch>=1.3.0+cpu
 pyro-ppl>=1.0.0
 numpyro>=0.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,6 @@
---find-links https://download.pytorch.org/whl/torch_stable.html
-
 sphinx
 sphinx_rtd_theme
 pandas
-torch>=1.3+cpu
+pip -f https://download.pytorch.org/whl/torch_stable.html torch>=1.3+cpu
 pyro-ppl>=1.0.0
 numpyro>=0.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+--find-links https://download.pytorch.org/whl/torch_stable.html
+
 sphinx
 sphinx_rtd_theme
 pandas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 sphinx
 sphinx_rtd_theme
 pandas
-pip -f https://download.pytorch.org/whl/torch_stable.html torch>=1.3+cpu
 pyro-ppl>=1.0.0
 numpyro>=0.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,6 @@
 sphinx
 sphinx_rtd_theme
 pandas
+torch>=1.3+cpu
 pyro-ppl>=1.0.0
 numpyro>=0.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx
 sphinx_rtd_theme
 pandas
-pip -f https://download.pytorch.org/whl/torch_stable.html torch==1.3.0+cpu
+pip -f https://download.pytorch.org/whl/torch_stable.html torch>=1.3.0+cpu
 pyro-ppl>=0.5.1
-numpyro>=0.2.0'
+numpyro>=0.2.1

--- a/docs/requirements_torch.txt
+++ b/docs/requirements_torch.txt
@@ -1,0 +1,1 @@
+pip -f https://download.pytorch.org/whl/torch_stable.html torch>=1.3+cpu

--- a/docs/requirements_torch.txt
+++ b/docs/requirements_torch.txt
@@ -1,1 +1,3 @@
-pip -f https://download.pytorch.org/whl/torch_stable.html torch==1.3.0+cpu
+--find-links https://download.pytorch.org/whl/torch_stable.html
+
+torch==1.3.0+cpu

--- a/docs/requirements_torch.txt
+++ b/docs/requirements_torch.txt
@@ -1,1 +1,1 @@
-pip -f https://download.pytorch.org/whl/torch_stable.html torch>=1.3+cpu
+pip -f https://download.pytorch.org/whl/torch_stable.html torch==1.3.0+cpu

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,8 +77,3 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
                        'numpy': ('http://docs.scipy.org/doc/numpy/', None),
                        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
                        }
-
-# XXX: This cannot be done in requirements.txt as that will trigger
-# installation of the most recent PyTorch version from pypi.
-if 'READTHEDOCS' in os.environ:
-    os.system('pip install torch==1.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,3 +77,8 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
                        'numpy': ('http://docs.scipy.org/doc/numpy/', None),
                        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
                        }
+
+# XXX: This cannot be done in requirements.txt as that will trigger
+# installation of the most recent PyTorch version from pypi.
+if 'READTHEDOCS' in os.environ:
+    os.system('pip install torch==1.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(name='brmp',
       packages=find_packages(),
       install_requires=[
         'pandas',
-        'pyro-ppl>=0.5.1',
+        'pyro-ppl>=1.0.0',
         'numpyro>=0.2.1',
       ],
       extras_require={

--- a/tests/test_brm.py
+++ b/tests/test_brm.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 import numpyro.handlers as numpyro
 import pandas as pd

--- a/tests/test_brm.py
+++ b/tests/test_brm.py
@@ -1043,8 +1043,7 @@ def test_coef_names(formula_str, non_real_cols, expected_names):
 @pytest.mark.parametrize('fitargs', [
     lambda S: dict(backend=pyro_backend, algo='prior', num_samples=S),
     lambda S: dict(backend=pyro_backend, iter=S, warmup=0),
-    pytest.param(lambda S: dict(backend=pyro_backend, iter=S // 2, num_chains=2, warmup=0),
-                 marks=pytest.mark.xfail('CI' in os.environ, reason='https://github.com/pyro-ppl/pyro/issues/2095')),
+    lambda S: dict(backend=pyro_backend, iter=S // 2, num_chains=2, warmup=0),
     lambda S: dict(backend=pyro_backend, algo='svi', iter=1, num_samples=S),
     lambda S: dict(backend=pyro_backend, algo='svi', iter=1, num_samples=S, subsample_size=1),
     lambda S: dict(backend=numpyro_backend, algo='prior', num_samples=S),


### PR DESCRIPTION
Additionally, attempts to fix #70. 

The issue is that we cannot enforce order in a `requirements.txt` file and since PyTorch released a  version `1.3.1` very recently, we were fetching a bigger file from pypi instead of the `1.3.0` cpu only hosted wheels (this was being fetched as a dependency of `pyro-ppl`). We could have fixed that by updating the torch dependency in `requirements.txt` to `1.3.1`, but this would be a recurring issue with each update to pytorch. 

Instead, the current workaround splits the installs into 2 requirement files - pytorch install + remaining, which should be more stable. 

[build](https://readthedocs.org/projects/brmp/builds/9982731/)