### PR TITLE
Allow integers to be used as categorical levels.

### DIFF
--- a/brmp/model.py
+++ b/brmp/model.py
@@ -124,7 +124,7 @@ def scalar_parameter_map(model):
     for ix, group in enumerate(model.groups):
         out.extend([('sd_{}__{}'.format(cols2str(group.columns), coef), ('sd_{}'.format(ix), (i,)))
                     for i, coef in enumerate(group.coefs)])
-        out.extend([('r_{}[{},{}]'.format(cols2str(group.columns), '_'.join(level), coef), ('r_{}'.format(ix), (i, j)))
+        out.extend([('r_{}[{},{}]'.format(cols2str(group.columns), level2str(level), coef), ('r_{}'.format(ix), (i, j)))
                     for j, coef in enumerate(group.coefs)
                     for i, level in enumerate(group.levels)])
     for param in model.response.nonlocparams:
@@ -134,3 +134,8 @@ def scalar_parameter_map(model):
 
 def scalar_parameter_names(model):
     return [name for (name, _) in scalar_parameter_map(model)]
+
+
+def level2str(level):
+    assert type(level) == tuple
+    return '_'.join(str(l) for l in level)

--- a/tests/test_brm.py
+++ b/tests/test_brm.py
@@ -86,6 +86,12 @@ codegen_cases = [
       ('z_0', 'Normal', {}),
       ('sd_0_0', 'HalfCauchy', {})]),
 
+    # Integers as categorical levels.
+    ('y ~ 1 | z', [Categorical('z', [10, 20])], {}, Normal, [],
+     [('sigma', 'HalfCauchy', {}),
+      ('z_0', 'Normal', {}),
+      ('sd_0_0', 'HalfCauchy', {})]),
+
     ('y ~ x | z', [Categorical('z', list('ab'))], {}, Normal, [],
      [('sigma', 'HalfCauchy', {}),
       ('z_0', 'Normal', {}),
@@ -544,6 +550,16 @@ def test_scalar_param_map_consistency():
         param_shape = ss[0]
         assert len(indices) == len(param_shape)
         assert all(i < s for (i, s) in zip(indices, param_shape))
+
+
+@pytest.mark.parametrize('formula_str, non_real_cols, contrasts, family, priors, expected', codegen_cases)
+def test_scalar_parameter_names_smoke(formula_str, non_real_cols, contrasts, family, priors, expected):
+    formula = parse(formula_str)
+    cols = expand_columns(formula, non_real_cols)
+    metadata = metadata_from_cols(cols)
+    model = define_model(formula_str, metadata, family, priors, contrasts)
+    names = scalar_parameter_names(model.desc)
+    assert type(names) == list
 
 
 @pytest.mark.parametrize('formula_str, non_real_cols, family, priors', [


### PR DESCRIPTION
This fixes #62. The root cause of that was a failure to correctly generate parameter names for a model when the levels of a category were not already strings. The test added here fails without the fix in this PR.