### PR TITLE
support for poisson

### DIFF
--- a/brmp/family.py
+++ b/brmp/family.py
@@ -132,9 +132,9 @@ StudentT = Family('StudentT',
 """
 
 Poisson = Family('Poisson',
-                  [param('rate', Type['PosReal']())],
-                  const(Type['IntegerRange'](0, None)),
-                  Link('rate', LinkFn.log))
+                 [param('rate', Type['PosReal']())],
+                 const(Type['IntegerRange'](0, None)),
+                 Link('rate', LinkFn.log))
 
 """
 :param rate: rate

--- a/brmp/family.py
+++ b/brmp/family.py
@@ -45,7 +45,7 @@ def istype(ty):
 
 
 # Inverse might also be called recip(rocal).
-LinkFn = Enum('LinkFn', 'identity logit inverse')
+LinkFn = Enum('LinkFn', 'identity logit inverse log')
 
 Link = namedtuple('Link', 'param fn')
 
@@ -129,6 +129,15 @@ StudentT = Family('StudentT',
 :param df: degrees of freedom
 :param loc: location
 :param scale: scale
+"""
+
+Poisson = Family('Poisson',
+                  [param('rate', Type['PosReal']())],
+                  const(Type['IntegerRange'](0, None)),
+                  Link('rate', LinkFn.log))
+
+"""
+:param rate: rate
 """
 
 

--- a/brmp/numpyro_codegen.py
+++ b/brmp/numpyro_codegen.py
@@ -202,6 +202,8 @@ def geninvlinkbody(linkfn, code):
         return code
     elif linkfn == LinkFn.logit:
         return 'sigmoid({})'.format(code)
+    elif linkfn == LinkFn.log:
+        return 'np.exp({})'.format(code)
     else:
         raise NotImplementedError('code generation for link function {} not implemented'.format(linkfn))
 

--- a/brmp/pyro_codegen.py
+++ b/brmp/pyro_codegen.py
@@ -192,6 +192,8 @@ def geninvlinkbody(linkfn, code):
         return code
     elif linkfn == LinkFn.logit:
         return 'torch.sigmoid({})'.format(code)
+    elif linkfn == LinkFn.log:
+        return 'torch.exp({})'.format(code)
     else:
         raise NotImplementedError('code generation for link function {} not implemented'.format(linkfn))
 

--- a/tests/test_brm.py
+++ b/tests/test_brm.py
@@ -79,9 +79,6 @@ codegen_cases = [
      [('b_0', 'Cauchy', {}),
       ('sigma', 'HalfCauchy', {})]),
 
-    ('y ~ 1 + x', [Integral('y', min=0, max=10), Integral('x', min=0, max=10)], {}, Poisson, [],
-     [('b_0', 'Cauchy', {})]),
-
     # (Formula('y', [], [Group([], 'z', True)]), [Categorical('z', list('ab'))], [], ['sigma', 'z_1']),
     # Groups with fewer than two terms don't sample the (Cholesky
     # decomp. of the) correlation matrix.
@@ -287,6 +284,13 @@ codegen_cases = [
      [Integral('y', min=0, max=10)],
      {},
      Binomial(num_trials=10),
+     [],
+     [('b_0', 'Cauchy', {})]),
+
+    ('y ~ 1 + x',
+     [Integral('y', min=0, max=10), Integral('x', min=0, max=10)],
+     {},
+     Poisson,
      [],
      [('b_0', 'Cauchy', {})]),
 


### PR DESCRIPTION
This PR addresses adding support for a Poisson family likelihood. I've tested that it works in both numpyro and pyro.

Reading through this issue, it looks like there was previous discussion of adding Poisson support: https://github.com/pyro-ppl/brmp/issues/56

I think this PR addresses everything but the gamma prior. Was the intent to support an overdispersed Poisson by default?

I'm not super familiar with BRMS, and I couldn't tell from the docs whether they support a standard Poisson or overdispersed version.